### PR TITLE
[Feat/18] board details

### DIFF
--- a/Trim-Api/src/main/java/trim/api/common/util/EnumMappingUtil.java
+++ b/Trim-Api/src/main/java/trim/api/common/util/EnumMappingUtil.java
@@ -1,0 +1,19 @@
+package trim.api.common.util;
+
+import org.mapstruct.Named;
+import trim.common.util.EnumConvertUtil;
+import trim.domains.board.dao.domain.MajorType;
+import trim.domains.member.dao.domain.SocialType;
+
+public class EnumMappingUtil {
+
+    @Named("stringToMajorType")
+    public static MajorType stringToMajorType(String majorType) {
+        return EnumConvertUtil.convert(MajorType.class, majorType);
+    }
+
+    @Named("stringToSocialType")
+    public static SocialType stringToSocialType(String socialType) {
+        return EnumConvertUtil.convert(SocialType.class, socialType);
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/board/BoardMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/board/BoardMapper.java
@@ -1,0 +1,17 @@
+package trim.api.domains.board;
+
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+import trim.api.domains.board.vo.response.BoardResponse;
+import trim.domains.board.dao.domain.Board;
+
+@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+public interface BoardMapper {
+
+    BoardMapper INSTANCE = Mappers.getMapper(BoardMapper.class);
+
+    @Mapping(target = "boardId", source = "board.id")
+    BoardResponse toBoardResponse(Board board);
+}

--- a/Trim-Api/src/main/java/trim/api/domains/board/controller/BoardApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/board/controller/BoardApiController.java
@@ -1,0 +1,36 @@
+package trim.api.domains.board.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.board.service.GetAllBoardsByPaginationUseCase;
+import trim.api.domains.board.vo.response.BoardSummaryResponse;
+
+import java.util.List;
+
+@Tag(name = "[메인페이지(전체 게시글)]")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/boards")
+public class BoardApiController {
+
+    private final GetAllBoardsByPaginationUseCase getAllBoardsByPaginationUseCase;
+
+    @Operation(summary = "모든 게시글을 시간순으로 정렬하여 조회합니다.")
+    @GetMapping
+    public ApiResponseDto<List<BoardSummaryResponse>> getAllBoardsByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize
+    ) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize, Sort.by("createdAt").descending());
+        return ApiResponseDto.onSuccess(getAllBoardsByPaginationUseCase.execute(pageable));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/board/service/GetAllBoardsByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/board/service/GetAllBoardsByPaginationUseCase.java
@@ -1,0 +1,30 @@
+package trim.api.domains.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.board.vo.response.BoardSummaryResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.BoardAdaptor;
+import trim.domains.board.dao.domain.Board;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetAllBoardsByPaginationUseCase {
+
+    private final BoardAdaptor boardAdaptor;
+    private final LikeAdaptor likeAdaptor;
+
+    public List<BoardSummaryResponse> execute(Pageable pageable) {
+        Page<Board> boards = boardAdaptor.queryAllBoards(pageable);
+        return boards.getContent().stream()
+                .map(board ->
+                        BoardSummaryResponse.of(board, board.getWriter(), likeAdaptor.queryCountByBoard(board.getId())))
+                .toList();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/board/vo/response/BoardResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/board/vo/response/BoardResponse.java
@@ -1,0 +1,19 @@
+package trim.api.domains.board.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.domains.board.dao.domain.BoardType;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class BoardResponse {
+
+    private final Long boardId;
+    private final String title;
+    private final LocalDate createdAt;
+    private final BoardType boardType;
+}

--- a/Trim-Api/src/main/java/trim/api/domains/board/vo/response/BoardSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/board/vo/response/BoardSummaryResponse.java
@@ -1,0 +1,28 @@
+package trim.api.domains.board.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.api.domains.board.BoardMapper;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.member.vo.MemberResponse;
+import trim.domains.board.dao.domain.Board;
+import trim.domains.member.dao.domain.Member;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class BoardSummaryResponse {
+
+    private final BoardResponse boardResponse;
+    private final MemberResponse memberResponse;
+    private final Long likeCount;
+
+    public static BoardSummaryResponse of(Board board, Member member, Long likeCount) {
+        return BoardSummaryResponse.builder()
+                .boardResponse(BoardMapper.INSTANCE.toBoardResponse(board))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(member))
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.comment.service.GetCommentCountUseCase;
-import trim.api.domains.comment.service.WriteFreeTalkCommentUseCase;
-import trim.api.domains.comment.service.WriteQuestionCommentUseCase;
+import trim.api.domains.comment.service.WriteCommentUseCase;
 import trim.api.domains.comment.service.GetCommentsOfBoardUseCase;
+import trim.api.domains.comment.vo.request.CommentRequest;
 import trim.api.domains.comment.vo.response.CommentDetailResponse;
 
 import java.util.List;
@@ -20,8 +20,7 @@ import java.util.List;
 public class CommentApiController {
 
     private final GetCommentsOfBoardUseCase getCommentsOfBoardUseCase;
-    private final WriteQuestionCommentUseCase writeQuestionCommentUseCase;
-    private final WriteFreeTalkCommentUseCase writeFreeTalkCommentUseCase;
+    private final WriteCommentUseCase writeCommentUseCase;
     private final GetCommentCountUseCase getCommentCountUseCase;
 
     @Operation(summary = "게시글의 모든 댓글을 조회합니다. 이때 게시글은 PK로 조회합니다.")
@@ -30,19 +29,12 @@ public class CommentApiController {
         return ApiResponseDto.onSuccess(getCommentsOfBoardUseCase.execute(boardId));
     }
 
-    @Operation(summary = "질문 게시판의 댓글을 작성합니다.")
-    @PostMapping("/questions/{questionId}/members/{memberId}")
-    public ApiResponseDto<Long> writeQuestionComment(@PathVariable Long memberId,
-                                                      @PathVariable Long questionId,
-                                                      @RequestBody String content) {
-        return ApiResponseDto.onSuccess(writeQuestionCommentUseCase.execute(memberId, questionId, content));
-    }
-    @Operation(summary = "자유 게시판의 댓글을 작성합니다.")
-    @PostMapping("/free-talks/{freeTalkId}/members/{memberId}")
-    public ApiResponseDto<Long> writeFreeTalkComment(@PathVariable Long memberId,
-                                                      @PathVariable Long freeTalkId,
-                                                      @RequestBody String content) {
-        return ApiResponseDto.onSuccess(writeFreeTalkCommentUseCase.execute(memberId, freeTalkId, content));
+    @Operation(summary = "게시글의 댓글을 작성합니다. 이때 게시글의 타입은 신경쓰지 않습니다.")
+    @PostMapping("/boards/{boardId}/members/{memberId}")
+    public ApiResponseDto<Long> writeComment(@PathVariable Long boardId,
+                                             @PathVariable Long memberId,
+                                             @RequestBody CommentRequest request) {
+        return ApiResponseDto.onSuccess(writeCommentUseCase.execute(memberId, boardId, request.getContent()));
     }
 
     @Operation(summary = "게시글의 댓글 개수를 조회합니다. 주로 상세페이지에서 사용될 예정입니다.")

--- a/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class CommentApiController {
 
     private final GetCommentsOfBoardUseCase getCommentsOfBoardUseCase;
-    private final WriteQuestionCommentUseCase writeQuestionCommentUseCaseUseCase;
+    private final WriteQuestionCommentUseCase writeQuestionCommentUseCase;
     private final WriteFreeTalkCommentUseCase writeFreeTalkCommentUseCase;
 
     @Operation(summary = "게시글의 모든 댓글을 조회합니다. 이때 게시글은 PK로 조회합니다.")
@@ -33,7 +33,7 @@ public class CommentApiController {
     public ApiResponseDto<Long> writeQuestionComment(@PathVariable Long memberId,
                                                       @PathVariable Long questionId,
                                                       @RequestBody String content) {
-        return ApiResponseDto.onSuccess(writeQuestionCommentUseCaseUseCase.execute(memberId, questionId, content));
+        return ApiResponseDto.onSuccess(writeQuestionCommentUseCase.execute(memberId, questionId, content));
     }
     @Operation(summary = "자유 게시판의 댓글을 작성합니다.")
     @PostMapping("/free-talks/{freeTalkId}/members/{memberId}")

--- a/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.comment.service.GetCommentCountUseCase;
 import trim.api.domains.comment.service.WriteFreeTalkCommentUseCase;
 import trim.api.domains.comment.service.WriteQuestionCommentUseCase;
 import trim.api.domains.comment.service.GetCommentsOfBoardUseCase;
@@ -21,6 +22,7 @@ public class CommentApiController {
     private final GetCommentsOfBoardUseCase getCommentsOfBoardUseCase;
     private final WriteQuestionCommentUseCase writeQuestionCommentUseCase;
     private final WriteFreeTalkCommentUseCase writeFreeTalkCommentUseCase;
+    private final GetCommentCountUseCase getCommentCountUseCase;
 
     @Operation(summary = "게시글의 모든 댓글을 조회합니다. 이때 게시글은 PK로 조회합니다.")
     @GetMapping("/{boardId}")
@@ -41,5 +43,11 @@ public class CommentApiController {
                                                       @PathVariable Long freeTalkId,
                                                       @RequestBody String content) {
         return ApiResponseDto.onSuccess(writeFreeTalkCommentUseCase.execute(memberId, freeTalkId, content));
+    }
+
+    @Operation(summary = "게시글의 댓글 개수를 조회합니다. 주로 상세페이지에서 사용될 예정입니다.")
+    @GetMapping("/boards/{boardId}")
+    public ApiResponseDto<Long> getCommentCount(@PathVariable Long boardId) {
+        return ApiResponseDto.onSuccess(getCommentCountUseCase.execute(boardId));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/comment/service/GetCommentCountUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/service/GetCommentCountUseCase.java
@@ -1,0 +1,18 @@
+package trim.api.domains.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.common.annotation.UseCase;
+import trim.domains.comment.business.adaptor.CommentAdaptor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetCommentCountUseCase {
+
+    private final CommentAdaptor commentAdaptor;
+
+    public Long execute(Long boardId) {
+        return commentAdaptor.queryCountByBoardId(boardId);
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/comment/service/WriteCommentUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/service/WriteCommentUseCase.java
@@ -9,14 +9,13 @@ import trim.domains.member.business.adaptor.MemberAdaptor;
 
 @UseCase
 @RequiredArgsConstructor
-public class WriteQuestionCommentUseCase {
+public class WriteCommentUseCase {
 
-    private final QuestionAdaptor questionAdaptor;
-    private final CommentDomainService questionCommentDomainService;
+    private final CommentDomainService commentDomainService;
     private final MemberAdaptor memberAdaptor;
 
     public Long execute(Long memberId, Long questionId, String content){
-        return questionCommentDomainService.createComment(
+        return commentDomainService.createComment(
                 memberAdaptor.queryMember(memberId),
                 questionId,
                 content

--- a/Trim-Api/src/main/java/trim/api/domains/comment/vo/request/CommentRequest.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/vo/request/CommentRequest.java
@@ -1,0 +1,12 @@
+package trim.api.domains.comment.vo.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class CommentRequest {
+    private final String content;
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -10,6 +10,7 @@ import trim.api.domains.freetalk.service.GetSpecificFreeTalkUseCase;
 import trim.api.domains.freetalk.service.WriteFreeTalkUseCase;
 import trim.api.domains.freetalk.vo.FreeTalkDetailResponse;
 import trim.api.domains.freetalk.vo.FreeTalkRequest;
+import trim.api.domains.freetalk.vo.FreeTalkSummaryResponse;
 
 import java.util.List;
 
@@ -30,9 +31,9 @@ public class FreeTalkApiController {
         return ApiResponseDto.onSuccess(writeFreeTalkUseCase.execute(request, memberId));
     }
 
-    @Operation(summary = "자유 게시판 글을 모두 조회합니다.")
+    @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 조회 형식은 요약본입니다.")
     @GetMapping
-    public ApiResponseDto<List<FreeTalkDetailResponse>> getAllFreeTalk() {
+    public ApiResponseDto<List<FreeTalkSummaryResponse>> getAllFreeTalk() {
         return ApiResponseDto.onSuccess(getAllFreeTalkUseCase.execute());
     }
 

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -8,9 +8,9 @@ import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.freetalk.service.GetAllFreeTalkUseCase;
 import trim.api.domains.freetalk.service.GetSpecificFreeTalkUseCase;
 import trim.api.domains.freetalk.service.WriteFreeTalkUseCase;
-import trim.api.domains.freetalk.vo.FreeTalkDetailResponse;
-import trim.api.domains.freetalk.vo.FreeTalkRequest;
-import trim.api.domains.freetalk.vo.FreeTalkSummaryResponse;
+import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
+import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
+import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
 
 import java.util.List;
 

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -3,8 +3,11 @@ package trim.api.domains.freetalk.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.freetalk.service.GetAllFreeTalkByPaginationUseCase;
 import trim.api.domains.freetalk.service.GetAllFreeTalkUseCase;
 import trim.api.domains.freetalk.service.GetSpecificFreeTalkUseCase;
 import trim.api.domains.freetalk.service.WriteFreeTalkUseCase;
@@ -23,6 +26,7 @@ public class FreeTalkApiController {
     private final WriteFreeTalkUseCase writeFreeTalkUseCase;
     private final GetAllFreeTalkUseCase getAllFreeTalkUseCase;
     private final GetSpecificFreeTalkUseCase getSpecificFreeTalkUseCase;
+    private final GetAllFreeTalkByPaginationUseCase getAllFreeTalkByPaginationUseCase;
 
     @Operation(summary = "자유 게시판 글을 작성합니다.")
     @PostMapping("/members/{memberId}")
@@ -43,4 +47,12 @@ public class FreeTalkApiController {
         return ApiResponseDto.onSuccess(getSpecificFreeTalkUseCase.execute(freeTalkId));
     }
 
+    @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
+    @GetMapping("/page")
+    public ApiResponseDto<List<FreeTalkSummaryResponse>> getAllFreeTalkByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize);
+        return ApiResponseDto.onSuccess(getAllFreeTalkByPaginationUseCase.execute(pageable));
+    }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/mapper/FreeTalkMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/mapper/FreeTalkMapper.java
@@ -14,7 +14,9 @@ public interface FreeTalkMapper {
 
     FreeTalkMapper INSTANCE = Mappers.getMapper(FreeTalkMapper.class);
 
+    @Mapping(target = "freeTalkId", source = "freeTalk.id")
     @Mapping(target = "title", source = "freeTalk.title")
     @Mapping(target = "content", source = "freeTalk.content")
+    @Mapping(target = "createdAt", source = "freeTalk.createdAt")
     FreeTalkResponse toFreeTalkResponse(FreeTalk freeTalk);
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/mapper/FreeTalkMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/mapper/FreeTalkMapper.java
@@ -4,10 +4,8 @@ import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
-import trim.api.domains.freetalk.vo.FreeTalkResponse;
-import trim.api.domains.question.vo.response.QuestionResponse;
+import trim.api.domains.freetalk.vo.response.FreeTalkResponse;
 import trim.domains.board.dao.domain.FreeTalk;
-import trim.domains.board.dao.domain.Question;
 
 @Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
 public interface FreeTalkMapper {

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkByPaginationUseCase.java
@@ -1,0 +1,42 @@
+package trim.api.domains.freetalk.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.freetalk.mapper.FreeTalkMapper;
+import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.FreeTalkAdaptor;
+import trim.domains.board.dao.domain.FreeTalk;
+import trim.domains.comment.business.adaptor.CommentAdaptor;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class GetAllFreeTalkByPaginationUseCase {
+
+    private final FreeTalkAdaptor freeTalkAdaptor;
+    private final CommentAdaptor commentAdaptor;
+    private final LikeAdaptor likeAdaptor;
+
+    public List<FreeTalkSummaryResponse> execute(Pageable pageable) {
+        Page<FreeTalk> freeTalks = freeTalkAdaptor.queryAllFreeTalk(pageable);
+        return freeTalks.getContent().stream()
+                .map(this::mapToFreeTalkSummaryResponse)
+                .toList();
+    }
+
+    private FreeTalkSummaryResponse mapToFreeTalkSummaryResponse(FreeTalk freeTalk) {
+        return FreeTalkSummaryResponse.builder()
+                .freeTalkResponse(FreeTalkMapper.INSTANCE.toFreeTalkResponse(freeTalk))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(freeTalk.getWriter()))
+                .commentCount(commentAdaptor.queryCountByBoardId(freeTalk.getId()))
+                .likeCount(likeAdaptor.queryCountByBoard(freeTalk.getId()))
+                .build();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkUseCase.java
@@ -2,20 +2,14 @@ package trim.api.domains.freetalk.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import trim.api.domains.comment.mapper.CommentMapper;
-import trim.api.domains.comment.vo.response.CommentDetailResponse;
 import trim.api.domains.freetalk.mapper.FreeTalkMapper;
-import trim.api.domains.freetalk.vo.FreeTalkDetailResponse;
-import trim.api.domains.freetalk.vo.FreeTalkSummaryResponse;
+import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
 import trim.api.domains.member.mapper.MemberMapper;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.adaptor.FreeTalkAdaptor;
 import trim.domains.board.dao.domain.FreeTalk;
-import trim.domains.board.dao.domain.Question;
 import trim.domains.comment.business.adaptor.CommentAdaptor;
-import trim.domains.comment.dao.domain.Comment;
 import trim.domains.like.business.adaptor.LikeAdaptor;
-import trim.domains.like.business.validator.LikeValidator;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkUseCase.java
@@ -33,12 +33,11 @@ public class GetAllFreeTalkUseCase {
         List<FreeTalk> freeTalks = freeTalkAdaptor.queryAllFreeTalk();
 
         return freeTalks.stream()
-                .map(this::mapToFreeTalkDetailResponse)
+                .map(this::mapToFreeTalkSummaryResponse)
                 .collect(Collectors.toList());
     }
 
-    private FreeTalkSummaryResponse mapToFreeTalkDetailResponse(FreeTalk freeTalk) {
-        List<Comment> comments = commentAdaptor.queryAllByBoardId(freeTalk.getId());
+    private FreeTalkSummaryResponse mapToFreeTalkSummaryResponse(FreeTalk freeTalk) {
         return FreeTalkSummaryResponse.builder()
                 .freeTalkResponse(FreeTalkMapper.INSTANCE.toFreeTalkResponse(freeTalk))
                 .memberResponse(MemberMapper.INSTANCE.toMemberResponse(freeTalk.getWriter()))

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetSpecificFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetSpecificFreeTalkUseCase.java
@@ -13,6 +13,7 @@ import trim.domains.board.business.adaptor.FreeTalkAdaptor;
 import trim.domains.board.dao.domain.FreeTalk;
 import trim.domains.comment.business.adaptor.CommentAdaptor;
 import trim.domains.comment.dao.domain.Comment;
+import trim.domains.like.business.adaptor.LikeAdaptor;
 
 import java.util.List;
 
@@ -23,10 +24,13 @@ public class GetSpecificFreeTalkUseCase {
 
     private final FreeTalkAdaptor freeTalkAdaptor;
     private final CommentAdaptor commentAdaptor;
+    private final LikeAdaptor likeAdaptor;
 
     public FreeTalkDetailResponse execute(Long freeTalkId) {
         FreeTalk freeTalk = freeTalkAdaptor.queryFreeTalkById(freeTalkId);
         List<Comment> comments = commentAdaptor.queryAllByBoardId(freeTalkId);
-        return FreeTalkDetailResponse.of(freeTalk, comments);
+        Long likeCount = likeAdaptor.queryCountByBoard(freeTalkId);
+        Long commentCount = commentAdaptor.queryCountByBoardId(freeTalkId);
+        return FreeTalkDetailResponse.of(freeTalk, comments, likeCount, commentCount);
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetSpecificFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetSpecificFreeTalkUseCase.java
@@ -19,13 +19,10 @@ public class GetSpecificFreeTalkUseCase {
 
     private final FreeTalkAdaptor freeTalkAdaptor;
     private final CommentAdaptor commentAdaptor;
-    private final LikeAdaptor likeAdaptor;
 
     public FreeTalkDetailResponse execute(Long freeTalkId) {
         FreeTalk freeTalk = freeTalkAdaptor.queryFreeTalkById(freeTalkId);
         List<Comment> comments = commentAdaptor.queryAllByBoardId(freeTalkId);
-        Long likeCount = likeAdaptor.queryCountByBoard(freeTalkId);
-        Long commentCount = commentAdaptor.queryCountByBoardId(freeTalkId);
-        return FreeTalkDetailResponse.of(freeTalk, comments, likeCount, commentCount);
+        return FreeTalkDetailResponse.of(freeTalk, comments);
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetSpecificFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetSpecificFreeTalkUseCase.java
@@ -2,12 +2,7 @@ package trim.api.domains.freetalk.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import trim.api.domains.comment.mapper.CommentMapper;
-import trim.api.domains.comment.vo.response.CommentDetailResponse;
-import trim.api.domains.freetalk.mapper.FreeTalkMapper;
-import trim.api.domains.freetalk.vo.FreeTalkDetailResponse;
-import trim.api.domains.freetalk.vo.FreeTalkResponse;
-import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.adaptor.FreeTalkAdaptor;
 import trim.domains.board.dao.domain.FreeTalk;

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/WriteFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/WriteFreeTalkUseCase.java
@@ -2,7 +2,7 @@ package trim.api.domains.freetalk.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import trim.api.domains.freetalk.vo.FreeTalkRequest;
+import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.service.FreeTalkDomainService;
 import trim.domains.member.business.adaptor.MemberAdaptor;

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkDetailResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkDetailResponse.java
@@ -21,14 +21,19 @@ import java.util.List;
 public class FreeTalkDetailResponse {
     private final FreeTalkResponse freeTalkResponse;
     private final MemberResponse memberResponse;
+    private final Long likeCount;
+    //    private boolean isLiked; TODO
+    private final Long commentCount;
     @Builder.Default
     private final List<CommentDetailResponse> commentDetailResponseList = new ArrayList<>();
 
-    public static FreeTalkDetailResponse of(FreeTalk freeTalk, List<Comment> comments) {
+    public static FreeTalkDetailResponse of(FreeTalk freeTalk, List<Comment> comments, Long likeCount, Long commentCount) {
         return FreeTalkDetailResponse.builder()
                 .freeTalkResponse(FreeTalkMapper.INSTANCE.toFreeTalkResponse(freeTalk))
                 .memberResponse(MemberMapper.INSTANCE.toMemberResponse(freeTalk.getWriter()))
                 .commentDetailResponseList(comments.stream().map(CommentDetailResponse::of).toList())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkResponse.java
@@ -5,10 +5,14 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 @RequiredArgsConstructor
 public class FreeTalkResponse {
+    private final Long freeTalkId;
     private final String title;
     private final String content;
+    private LocalDate createdAt;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkResponse.java
@@ -14,5 +14,5 @@ public class FreeTalkResponse {
     private final Long freeTalkId;
     private final String title;
     private final String content;
-    private LocalDate createdAt;
+    private final LocalDate createdAt;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkSummaryResponse.java
@@ -1,0 +1,20 @@
+package trim.api.domains.freetalk.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.api.domains.member.vo.MemberResponse;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class FreeTalkSummaryResponse {
+    private final FreeTalkResponse freeTalkResponse;
+    private final MemberResponse memberResponse;
+    private Long likeCount;
+//    private boolean isLiked; TODO
+    private Long commentCount;
+
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/FreeTalkSummaryResponse.java
@@ -13,8 +13,8 @@ import java.time.LocalDate;
 public class FreeTalkSummaryResponse {
     private final FreeTalkResponse freeTalkResponse;
     private final MemberResponse memberResponse;
-    private Long likeCount;
+    private final Long likeCount;
 //    private boolean isLiked; TODO
-    private Long commentCount;
+    private final Long commentCount;
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/request/FreeTalkRequest.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/request/FreeTalkRequest.java
@@ -1,4 +1,4 @@
-package trim.api.domains.freetalk.vo;
+package trim.api.domains.freetalk.vo.request;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkDetailResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkDetailResponse.java
@@ -19,19 +19,14 @@ import java.util.List;
 public class FreeTalkDetailResponse {
     private final FreeTalkResponse freeTalkResponse;
     private final MemberResponse memberResponse;
-    private final Long likeCount;
-    //    private boolean isLiked; TODO
-    private final Long commentCount;
     @Builder.Default
     private final List<CommentDetailResponse> commentDetailResponseList = new ArrayList<>();
 
-    public static FreeTalkDetailResponse of(FreeTalk freeTalk, List<Comment> comments, Long likeCount, Long commentCount) {
+    public static FreeTalkDetailResponse of(FreeTalk freeTalk, List<Comment> comments) {
         return FreeTalkDetailResponse.builder()
                 .freeTalkResponse(FreeTalkMapper.INSTANCE.toFreeTalkResponse(freeTalk))
                 .memberResponse(MemberMapper.INSTANCE.toMemberResponse(freeTalk.getWriter()))
                 .commentDetailResponseList(comments.stream().map(CommentDetailResponse::of).toList())
-                .likeCount(likeCount)
-                .commentCount(commentCount)
                 .build();
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkDetailResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkDetailResponse.java
@@ -1,15 +1,13 @@
-package trim.api.domains.freetalk.vo;
+package trim.api.domains.freetalk.vo.response;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import trim.api.domains.comment.vo.response.CommentDetailResponse;
-import trim.api.domains.comment.vo.response.CommentResponse;
 import trim.api.domains.freetalk.mapper.FreeTalkMapper;
 import trim.api.domains.member.mapper.MemberMapper;
 import trim.api.domains.member.vo.MemberResponse;
 import trim.domains.board.dao.domain.FreeTalk;
-import trim.domains.board.dao.repository.FreeTalkRepository;
 import trim.domains.comment.dao.domain.Comment;
 
 import java.util.ArrayList;

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkResponse.java
@@ -1,7 +1,6 @@
-package trim.api.domains.freetalk.vo;
+package trim.api.domains.freetalk.vo.response;
 
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkSummaryResponse.java
@@ -1,11 +1,9 @@
-package trim.api.domains.freetalk.vo;
+package trim.api.domains.freetalk.vo.response;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import trim.api.domains.member.vo.MemberResponse;
-
-import java.time.LocalDate;
 
 @Getter
 @Builder

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -5,8 +5,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.knowledge.service.GetAllKnowledgeUseCase;
 import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
+
+import java.util.List;
 
 @Tag(name = "[지식 공유]")
 @RestController
@@ -15,11 +19,18 @@ import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 public class KnowledgeApiController {
 
     private final WriteKnowledgeUseCase writeKnowledgeUseCase;
+    private final GetAllKnowledgeUseCase getAllKnowledgeUseCase;
 
     @Operation(summary = "지식 공유 게시글을 작성합니다.")
     @PostMapping("/members/{memberId}")
     public ApiResponseDto<Long> writeKnowledge(@PathVariable Long memberId,
                                                @RequestBody KnowledgeRequest request) {
         return ApiResponseDto.onSuccess(writeKnowledgeUseCase.execute(memberId, request));
+    }
+
+    @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 형식은 요약입니다.")
+    @GetMapping
+    public ApiResponseDto<List<KnowledgeSummaryResponse>> getAllKnowledge() {
+        return ApiResponseDto.onSuccess(getAllKnowledgeUseCase.execute());
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -38,8 +38,8 @@ public class KnowledgeApiController {
     }
 
     @Operation(summary = "특정 지식 공유 게시글을 조회합니다. 조회 시 지식 공유의 랜덤난수 키값이 필요합니다.")
-    @GetMapping("/{knowledgeUuid}")
-    public ApiResponseDto<KnowledgeDetailResponse> getSpecificKnowledge(@PathVariable String knowledgeUuid) {
-        return ApiResponseDto.onSuccess(getSpecificKnowledgeUseCase.execute(knowledgeUuid));
+    @GetMapping("/{knowledgeId}")
+    public ApiResponseDto<KnowledgeDetailResponse> getSpecificKnowledge(@PathVariable Long knowledgeId) {
+        return ApiResponseDto.onSuccess(getSpecificKnowledgeUseCase.execute(knowledgeId));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.knowledge.service.GetAllKnowledgeUseCase;
+import trim.api.domains.knowledge.service.GetSpecificKnowledgeUseCase;
 import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
 import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
 
 import java.util.List;
@@ -20,6 +22,7 @@ public class KnowledgeApiController {
 
     private final WriteKnowledgeUseCase writeKnowledgeUseCase;
     private final GetAllKnowledgeUseCase getAllKnowledgeUseCase;
+    private final GetSpecificKnowledgeUseCase getSpecificKnowledgeUseCase;
 
     @Operation(summary = "지식 공유 게시글을 작성합니다.")
     @PostMapping("/members/{memberId}")
@@ -32,5 +35,11 @@ public class KnowledgeApiController {
     @GetMapping
     public ApiResponseDto<List<KnowledgeSummaryResponse>> getAllKnowledge() {
         return ApiResponseDto.onSuccess(getAllKnowledgeUseCase.execute());
+    }
+
+    @Operation(summary = "특정 지식 공유 게시글을 조회합니다. 조회 시 지식 공유의 랜덤난수 키값이 필요합니다.")
+    @GetMapping("/{knowledgeUuid}")
+    public ApiResponseDto<KnowledgeDetailResponse> getSpecificKnowledge(@PathVariable String knowledgeUuid) {
+        return ApiResponseDto.onSuccess(getSpecificKnowledgeUseCase.execute(knowledgeUuid));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -3,8 +3,11 @@ package trim.api.domains.knowledge.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.knowledge.service.GetAllKnowledgeByPaginationUseCase;
 import trim.api.domains.knowledge.service.GetAllKnowledgeUseCase;
 import trim.api.domains.knowledge.service.GetSpecificKnowledgeUseCase;
 import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
@@ -23,6 +26,7 @@ public class KnowledgeApiController {
     private final WriteKnowledgeUseCase writeKnowledgeUseCase;
     private final GetAllKnowledgeUseCase getAllKnowledgeUseCase;
     private final GetSpecificKnowledgeUseCase getSpecificKnowledgeUseCase;
+    private final GetAllKnowledgeByPaginationUseCase getAllKnowledgeByPaginationUseCase;
 
     @Operation(summary = "지식 공유 게시글을 작성합니다.")
     @PostMapping("/members/{memberId}")
@@ -37,9 +41,19 @@ public class KnowledgeApiController {
         return ApiResponseDto.onSuccess(getAllKnowledgeUseCase.execute());
     }
 
-    @Operation(summary = "특정 지식 공유 게시글을 조회합니다. 조회 시 지식 공유의 랜덤난수 키값이 필요합니다.")
+    @Operation(summary = "특정 지식 공유 게시글을 조회합니다.")
     @GetMapping("/{knowledgeId}")
     public ApiResponseDto<KnowledgeDetailResponse> getSpecificKnowledge(@PathVariable Long knowledgeId) {
         return ApiResponseDto.onSuccess(getSpecificKnowledgeUseCase.execute(knowledgeId));
+    }
+
+    @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
+    @GetMapping("/page")
+    public ApiResponseDto<List<KnowledgeSummaryResponse>> getAllKnowledgeByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize
+    ) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize);
+        return ApiResponseDto.onSuccess(getAllKnowledgeByPaginationUseCase.execute(pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -1,0 +1,25 @@
+package trim.api.domains.knowledge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
+import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+
+@Tag(name = "[지식 공유]")
+@RestController
+@RequestMapping("/api/knowledge")
+@RequiredArgsConstructor
+public class KnowledgeApiController {
+
+    private final WriteKnowledgeUseCase writeKnowledgeUseCase;
+
+    @Operation(summary = "지식 공유 게시글을 작성합니다.")
+    @PostMapping("/members/{memberId}")
+    public ApiResponseDto<Long> writeKnowledge(@PathVariable Long memberId,
+                                               @RequestBody KnowledgeRequest request) {
+        return ApiResponseDto.onSuccess(writeKnowledgeUseCase.execute(memberId, request));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/mapper/KnowledgeMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/mapper/KnowledgeMapper.java
@@ -1,0 +1,25 @@
+package trim.api.domains.knowledge.mapper;
+
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+import trim.api.common.util.EnumMappingUtil;
+import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.api.domains.question.vo.request.QuestionRequest;
+import trim.common.util.EnumConvertUtil;
+import trim.domains.board.dao.domain.MajorType;
+import trim.domains.board.dto.KnowledgeDto;
+import trim.domains.board.dto.QuestionDto;
+
+@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder= @Builder(disableBuilder = false))
+
+public interface KnowledgeMapper {
+
+    KnowledgeMapper INSTANCE = Mappers.getMapper(KnowledgeMapper.class);
+
+    @Mapping(target = "majorType", qualifiedByName = "stringToMajorType")
+    KnowledgeDto toKnowledgeDto(KnowledgeRequest knowledgeRequest);
+
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/mapper/KnowledgeMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/mapper/KnowledgeMapper.java
@@ -7,8 +7,10 @@ import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.api.domains.knowledge.vo.response.KnowledgeResponse;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.common.util.EnumConvertUtil;
+import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.board.dao.domain.MajorType;
 import trim.domains.board.dto.KnowledgeDto;
 import trim.domains.board.dto.QuestionDto;
@@ -22,4 +24,9 @@ public interface KnowledgeMapper {
     @Mapping(target = "majorType", qualifiedByName = "stringToMajorType")
     KnowledgeDto toKnowledgeDto(KnowledgeRequest knowledgeRequest);
 
+    @Mapping(target = "knowledgeId", source = "knowledge.id")
+    @Mapping(target = "title", source = "knowledge.title")
+    @Mapping(target = "content", source = "knowledge.content")
+    @Mapping(target = "createdAt", source = "knowledge.createdAt")
+    KnowledgeResponse toKnowledgeResponse(Knowledge knowledge);
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeByPaginationUseCase.java
@@ -1,0 +1,40 @@
+package trim.api.domains.knowledge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.KnowledgeAdaptor;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.comment.business.adaptor.CommentAdaptor;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+import trim.domains.tag.business.adaptor.TagAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetAllKnowledgeByPaginationUseCase {
+
+    private final KnowledgeAdaptor knowledgeAdaptor;
+    private final CommentAdaptor commentAdaptor;
+    private final LikeAdaptor likeAdaptor;
+    private final TagAdaptor tagAdaptor;
+
+    public List<KnowledgeSummaryResponse> execute(Pageable pageable) {
+        Page<Knowledge> knowledgePage = knowledgeAdaptor.queryAllKnowledge(pageable);
+        return knowledgePage.getContent().stream()
+                .map(knowledge ->
+                        KnowledgeSummaryResponse.of(
+                                knowledge,
+                                knowledge.getWriter(),
+                                likeAdaptor.queryCountByBoard(knowledge.getId()),
+                                commentAdaptor.queryCountByBoardId(knowledge.getId()),
+                                tagAdaptor.queryNamesByBoardId(knowledge.getId())))
+                .toList();
+
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeUseCase.java
@@ -1,0 +1,37 @@
+package trim.api.domains.knowledge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.KnowledgeAdaptor;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.comment.business.adaptor.CommentAdaptor;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+import trim.domains.tag.business.adaptor.TagAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetAllKnowledgeUseCase {
+
+    private final KnowledgeAdaptor knowledgeAdaptor;
+    private final TagAdaptor tagAdaptor;
+    private final LikeAdaptor likeAdaptor;
+    private final CommentAdaptor commentAdaptor;
+
+    public List<KnowledgeSummaryResponse> execute() {
+        List<Knowledge> knowledgeList = knowledgeAdaptor.queryAllKnowledge();
+        return knowledgeList.stream()
+                .map(knowledge ->
+                        KnowledgeSummaryResponse.of(
+                                knowledge,
+                                knowledge.getWriter(),
+                                likeAdaptor.queryCountByBoard(knowledge.getId()),
+                                commentAdaptor.queryCountByBoardId(knowledge.getId()),
+                                tagAdaptor.queryNamesByBoardId(knowledge.getId())))
+                .toList();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetSpecificKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetSpecificKnowledgeUseCase.java
@@ -1,0 +1,30 @@
+package trim.api.domains.knowledge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.KnowledgeAdaptor;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.comment.business.adaptor.CommentAdaptor;
+import trim.domains.comment.dao.domain.Comment;
+import trim.domains.tag.business.adaptor.TagAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetSpecificKnowledgeUseCase {
+
+    private final KnowledgeAdaptor knowledgeAdaptor;
+    private final CommentAdaptor commentAdaptor;
+    private final TagAdaptor tagAdaptor;
+
+    public KnowledgeDetailResponse execute(String knowledgeUuid) {
+        Knowledge knowledge = knowledgeAdaptor.queryKnowledgeByUuid(knowledgeUuid);
+        List<Comment> comments = commentAdaptor.queryAllByBoardId(knowledge.getId());
+        List<String> tags = tagAdaptor.queryNamesByBoardId(knowledge.getId());
+        return KnowledgeDetailResponse.of(knowledge, knowledge.getWriter(), comments, tags);
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetSpecificKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetSpecificKnowledgeUseCase.java
@@ -21,8 +21,8 @@ public class GetSpecificKnowledgeUseCase {
     private final CommentAdaptor commentAdaptor;
     private final TagAdaptor tagAdaptor;
 
-    public KnowledgeDetailResponse execute(String knowledgeUuid) {
-        Knowledge knowledge = knowledgeAdaptor.queryKnowledgeByUuid(knowledgeUuid);
+    public KnowledgeDetailResponse execute(Long knowledgeId) {
+        Knowledge knowledge = knowledgeAdaptor.queryKnowledgeById(knowledgeId);
         List<Comment> comments = commentAdaptor.queryAllByBoardId(knowledge.getId());
         List<String> tags = tagAdaptor.queryNamesByBoardId(knowledge.getId());
         return KnowledgeDetailResponse.of(knowledge, knowledge.getWriter(), comments, tags);

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/WriteKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/WriteKnowledgeUseCase.java
@@ -1,0 +1,27 @@
+package trim.api.domains.knowledge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.knowledge.mapper.KnowledgeMapper;
+import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.service.KnowledgeDomainService;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class WriteKnowledgeUseCase {
+
+    private final KnowledgeDomainService knowledgeDomainService;
+    private final MemberAdaptor memberAdaptor;
+
+    public Long execute(Long memberId, KnowledgeRequest knowledgeRequest) {
+        Member member = memberAdaptor.queryMember(memberId);
+        Knowledge knowledge = knowledgeDomainService
+                .createKnowledge(member, KnowledgeMapper.INSTANCE.toKnowledgeDto(knowledgeRequest));
+        return knowledge.getId();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/WriteKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/WriteKnowledgeUseCase.java
@@ -9,6 +9,7 @@ import trim.domains.board.business.service.KnowledgeDomainService;
 import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
+import trim.domains.tag.business.service.TagDomainService;
 
 @UseCase
 @Transactional
@@ -16,12 +17,14 @@ import trim.domains.member.dao.domain.Member;
 public class WriteKnowledgeUseCase {
 
     private final KnowledgeDomainService knowledgeDomainService;
+    private final TagDomainService tagDomainService;
     private final MemberAdaptor memberAdaptor;
 
     public Long execute(Long memberId, KnowledgeRequest knowledgeRequest) {
         Member member = memberAdaptor.queryMember(memberId);
         Knowledge knowledge = knowledgeDomainService
                 .createKnowledge(member, KnowledgeMapper.INSTANCE.toKnowledgeDto(knowledgeRequest));
+        tagDomainService.addTagsInBoard(knowledge.getId(), knowledgeRequest.getTags());
         return knowledge.getId();
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/request/KnowledgeRequest.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/request/KnowledgeRequest.java
@@ -1,0 +1,19 @@
+package trim.api.domains.knowledge.vo.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class KnowledgeRequest {
+    private final String title;
+    private final String content;
+    private final String majorType;
+    @Builder.Default
+    private final List<String> tags = new ArrayList<>();
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeDetailResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeDetailResponse.java
@@ -1,0 +1,38 @@
+package trim.api.domains.knowledge.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.api.domains.comment.vo.response.CommentDetailResponse;
+import trim.api.domains.comment.vo.response.CommentResponse;
+import trim.api.domains.knowledge.mapper.KnowledgeMapper;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.member.vo.MemberResponse;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.comment.dao.domain.Comment;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class KnowledgeDetailResponse {
+
+    private final KnowledgeResponse knowledgeResponse;
+    private final MemberResponse memberResponse;
+    @Builder.Default
+    private final List<CommentDetailResponse> commentResponses = new ArrayList<>();
+    @Builder.Default
+    private final List<String> tags = new ArrayList<>();
+
+    public static KnowledgeDetailResponse of(Knowledge knowledge, Member member, List<Comment> comments, List<String> tags) {
+        return KnowledgeDetailResponse.builder()
+                .knowledgeResponse(KnowledgeMapper.INSTANCE.toKnowledgeResponse(knowledge))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(member))
+                .commentResponses(comments.stream().map(CommentDetailResponse::of).toList())
+                .tags(tags)
+                .build();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeResponse.java
@@ -1,0 +1,20 @@
+package trim.api.domains.knowledge.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.domains.board.dao.domain.MajorType;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class KnowledgeResponse {
+
+    private final Long knowledgeId;
+    private final String title;
+    private final String content;
+    private final LocalDate createdAt;
+    private final MajorType majorType;
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeSummaryResponse.java
@@ -1,0 +1,37 @@
+package trim.api.domains.knowledge.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.api.domains.knowledge.mapper.KnowledgeMapper;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.member.vo.MemberResponse;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class KnowledgeSummaryResponse {
+
+    private final KnowledgeResponse knowledgeResponse;
+    private final MemberResponse memberResponse;
+    private final Long likeCount;
+    private final Long commentCount;
+
+    @Builder.Default
+    private final List<String> tagList = new ArrayList<>();
+
+    public static KnowledgeSummaryResponse of(Knowledge knowledge, Member member, Long likeCount, Long commentCount, List<String> tags) {
+        return KnowledgeSummaryResponse.builder()
+                .knowledgeResponse(KnowledgeMapper.INSTANCE.toKnowledgeResponse(knowledge))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(member))
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .tagList(tags)
+                .build();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
@@ -1,0 +1,27 @@
+package trim.api.domains.like.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.like.service.ClickLikeAtTheBoardUseCase;
+
+@Tag(name = "[좋아요]")
+@RestController
+@RequestMapping("/api/likes")
+@RequiredArgsConstructor
+public class LikeApiController {
+
+    private final ClickLikeAtTheBoardUseCase clickLikeAtTheBoardUseCase;
+
+    @Operation(summary = "해당 게시글에 좋아요를 누릅니다.이미 존재하는 좋아요라면 취소합니다.")
+    @PostMapping("/boards/{boardId}/members/{memberId}")
+    public ApiResponseDto<String> clickLikeAtTheBoard(@PathVariable Long boardId,
+                                                       @PathVariable Long memberId) {
+        return ApiResponseDto.onSuccess(clickLikeAtTheBoardUseCase.execute(boardId, memberId));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
@@ -3,12 +3,10 @@ package trim.api.domains.like.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.like.service.ClickLikeAtTheBoardUseCase;
+import trim.api.domains.like.service.GetLikeCountUseCase;
 
 @Tag(name = "[좋아요]")
 @RestController
@@ -17,6 +15,7 @@ import trim.api.domains.like.service.ClickLikeAtTheBoardUseCase;
 public class LikeApiController {
 
     private final ClickLikeAtTheBoardUseCase clickLikeAtTheBoardUseCase;
+    private final GetLikeCountUseCase getLikeCountUseCase;
 
     @Operation(summary = "해당 게시글에 좋아요를 누릅니다.이미 존재하는 좋아요라면 취소합니다.")
     @PostMapping("/boards/{boardId}/members/{memberId}")
@@ -24,4 +23,11 @@ public class LikeApiController {
                                                        @PathVariable Long memberId) {
         return ApiResponseDto.onSuccess(clickLikeAtTheBoardUseCase.execute(boardId, memberId));
     }
+
+    @Operation(summary = "해당 게시글의 좋아요 개수를 조회합니다. 주로 게시글 상세 조회에서 사용될 예정입니다.")
+    @GetMapping("/boards/{boardId}")
+    public ApiResponseDto<Long> getLikeCount(@PathVariable Long boardId) {
+        return ApiResponseDto.onSuccess(getLikeCountUseCase.execute(boardId));
+    }
+
 }

--- a/Trim-Api/src/main/java/trim/api/domains/like/service/ClickLikeAtTheBoardUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/service/ClickLikeAtTheBoardUseCase.java
@@ -24,6 +24,6 @@ public class ClickLikeAtTheBoardUseCase {
             return LIKE_REMOVE_STATUS;
         }
         likeDomainService.createLike(boardId, memberId);
-        return LIKE_REMOVE_STATUS;
+        return LIKE_CREATE_STATUS;
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/like/service/ClickLikeAtTheBoardUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/service/ClickLikeAtTheBoardUseCase.java
@@ -1,0 +1,29 @@
+package trim.api.domains.like.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.common.annotation.UseCase;
+import trim.common.util.StaticValues;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+import trim.domains.like.business.service.LikeDomainService;
+import trim.domains.like.business.validator.LikeValidator;
+
+import static trim.common.util.StaticValues.*;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class ClickLikeAtTheBoardUseCase {
+
+    private final LikeDomainService likeDomainService;
+    private final LikeValidator likeValidator;
+
+    public String execute(Long boardId, Long memberId) {
+        if (likeValidator.isExist(boardId, memberId)) {
+            likeDomainService.removeLikeByBoardAndMember(boardId, memberId);
+            return LIKE_REMOVE_STATUS;
+        }
+        likeDomainService.createLike(boardId, memberId);
+        return LIKE_REMOVE_STATUS;
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/like/service/GetLikeCountUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/service/GetLikeCountUseCase.java
@@ -1,0 +1,18 @@
+package trim.api.domains.like.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.common.annotation.UseCase;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetLikeCountUseCase {
+
+    private final LikeAdaptor likeAdaptor;
+
+    public Long execute(Long boardId) {
+        return likeAdaptor.queryCountByBoard(boardId);
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/member/mapper/MemberMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/mapper/MemberMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.member.vo.MemberRequest;
 import trim.api.domains.member.vo.MemberResponse;
 import trim.common.util.EnumConvertUtil;
@@ -12,7 +13,7 @@ import trim.domains.member.dao.domain.Member;
 import trim.domains.member.dao.domain.Profile;
 import trim.domains.member.dao.domain.SocialType;
 
-@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder = @Builder(disableBuilder = false))
 public interface MemberMapper {
 
     MemberMapper INSTANCE = Mappers.getMapper(MemberMapper.class);
@@ -24,10 +25,5 @@ public interface MemberMapper {
     @Mapping(target = "email", source = "profile.email")
     @Mapping(target = "memberId", source = "id")
     MemberResponse toMemberResponse(Member member);
-
-    @Named("stringToSocialType")
-    default SocialType stringToSocialType(String socialType) {
-        return EnumConvertUtil.convert(SocialType.class, socialType);
-    }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -8,6 +8,7 @@ import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionDetailResponse;
 import trim.api.domains.question.service.*;
+import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 
 
 import java.util.List;
@@ -38,7 +39,7 @@ public class QuestionApiController {
 
     @Operation(summary = "질문 게시판 리스트 조회 메서드입니다.")
     @GetMapping
-    public ApiResponseDto<List<QuestionDetailResponse>> getAllQuestions(){
+    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestions(){
         return ApiResponseDto.onSuccess(getAllQuestionUseCase.execute());
     }
 

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -3,6 +3,8 @@ package trim.api.domains.question.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.question.vo.request.QuestionRequest;
@@ -23,23 +25,24 @@ public class QuestionApiController {
     private final EditQuestionUseCase editQuestionUseCase;
     private final GetSpecificQuestionUseCase getSpecificQuestionUseCase;
     private final GetAllQuestionUseCase getAllQuestionUseCase;
+    private final GetAllQuestionByPaginationUseCase getAllQuestionByPaginationUseCase;
 
     @Operation(summary = "질문 게시판 작성 메서드입니다.")
     @PostMapping("/members/{memberId}")
-    public ApiResponseDto<Long> createQuestion(@PathVariable Long memberId, @RequestBody QuestionRequest request){
+    public ApiResponseDto<Long> createQuestion(@PathVariable Long memberId, @RequestBody QuestionRequest request) {
         return ApiResponseDto.onSuccess(createQuestionUseCase.execute(memberId, request));
 
     }
 
     @Operation(summary = "질문 게시판 조회 메서드입니다. 질문 게시판의 pk를 통해 조회합니다.")
     @GetMapping("/{questionId}")
-    public ApiResponseDto<QuestionDetailResponse> getSpecificQuestion(@PathVariable Long questionId){
+    public ApiResponseDto<QuestionDetailResponse> getSpecificQuestion(@PathVariable Long questionId) {
         return ApiResponseDto.onSuccess(getSpecificQuestionUseCase.execute(questionId));
     }
 
     @Operation(summary = "질문 게시판 리스트 조회 메서드입니다.")
     @GetMapping
-    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestions(){
+    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestions() {
         return ApiResponseDto.onSuccess(getAllQuestionUseCase.execute());
     }
 
@@ -52,4 +55,13 @@ public class QuestionApiController {
         return ApiResponseDto.onSuccess(true);
     }
 
+    @Operation(summary = "질문 게시판을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
+    @GetMapping("/page")
+    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestionByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize
+    ) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize);
+        return ApiResponseDto.onSuccess(getAllQuestionByPaginationUseCase.execute(pageable));
+    }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionResponse;
 import trim.common.util.EnumConvertUtil;
@@ -13,7 +14,7 @@ import trim.domains.board.dao.domain.Question;
 import trim.domains.board.dto.QuestionDto;
 import trim.domains.member.dao.domain.SocialType;
 
-@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder = @Builder(disableBuilder = false))
 public interface QuestionMapper {
 
     QuestionMapper INSTANCE = Mappers.getMapper(QuestionMapper.class);
@@ -26,10 +27,5 @@ public interface QuestionMapper {
 
     @Mapping(target = "majorType", qualifiedByName = "stringToMajorType")
     QuestionDto toQuestionDto(QuestionRequest questionRequest);
-
-    @Named("stringToMajorType")
-    default MajorType stringToMajorType(String majorType) {
-        return EnumConvertUtil.convert(MajorType.class, majorType);
-    }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
@@ -12,6 +12,7 @@ public interface QuestionMapper {
 
     QuestionMapper INSTANCE = Mappers.getMapper(QuestionMapper.class);
 
+    @Mapping(target = "questionId", source = "question.id")
     @Mapping(target = "title", source = "question.title")
     @Mapping(target = "content", source = "question.content")
     @Mapping(target = "createdAt", source = "question.createdAt")

--- a/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
@@ -22,7 +22,6 @@ public interface QuestionMapper {
     @Mapping(target = "title", source = "question.title")
     @Mapping(target = "content", source = "question.content")
     @Mapping(target = "createdAt", source = "question.createdAt")
-    @Mapping(target = "majorType", source = "question.majorType")
     QuestionResponse toQuestionResponse(Question question);
 
     @Mapping(target = "majorType", qualifiedByName = "stringToMajorType")

--- a/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
@@ -3,9 +3,15 @@ package trim.api.domains.question.mapper;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionResponse;
+import trim.common.util.EnumConvertUtil;
+import trim.domains.board.dao.domain.MajorType;
 import trim.domains.board.dao.domain.Question;
+import trim.domains.board.dto.QuestionDto;
+import trim.domains.member.dao.domain.SocialType;
 
 @Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
 public interface QuestionMapper {
@@ -16,6 +22,15 @@ public interface QuestionMapper {
     @Mapping(target = "title", source = "question.title")
     @Mapping(target = "content", source = "question.content")
     @Mapping(target = "createdAt", source = "question.createdAt")
+    @Mapping(target = "majorType", source = "question.majorType")
     QuestionResponse toQuestionResponse(Question question);
+
+    @Mapping(target = "majorType", qualifiedByName = "stringToMajorType")
+    QuestionDto toQuestionDto(QuestionRequest questionRequest);
+
+    @Named("stringToMajorType")
+    default MajorType stringToMajorType(String majorType) {
+        return EnumConvertUtil.convert(MajorType.class, majorType);
+    }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/CreateQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/CreateQuestionUseCase.java
@@ -2,6 +2,7 @@ package trim.api.domains.question.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.question.mapper.QuestionMapper;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.service.QuestionDomainService;
@@ -23,7 +24,10 @@ public class CreateQuestionUseCase {
     @Transactional
     public Long execute(Long memberId, QuestionRequest questionRequest) {
         Member writer = memberAdaptor.queryMember(memberId);
-        Question question = questionDomainService.writeQuestion(writer, questionRequest.from());
+        Question question = questionDomainService.writeQuestion(
+                writer,
+                QuestionMapper.INSTANCE.toQuestionDto(questionRequest)
+        );
         tagDomainService.addTagsInBoard(question.getId(), questionRequest.getTags());
         return question.getId();
     }

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/CreateQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/CreateQuestionUseCase.java
@@ -1,6 +1,7 @@
 package trim.api.domains.question.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import trim.api.domains.question.mapper.QuestionMapper;
 import trim.api.domains.question.vo.request.QuestionRequest;
@@ -12,6 +13,7 @@ import trim.domains.member.dao.domain.Member;
 import trim.domains.tag.business.service.TagDomainService;
 
 
+@Slf4j
 @UseCase
 @Transactional
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class CreateQuestionUseCase {
     @Transactional
     public Long execute(Long memberId, QuestionRequest questionRequest) {
         Member writer = memberAdaptor.queryMember(memberId);
+        log.info("major type = {}", questionRequest.getMajorType());
         Question question = questionDomainService.writeQuestion(
                 writer,
                 QuestionMapper.INSTANCE.toQuestionDto(questionRequest)

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/GetAllQuestionByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/GetAllQuestionByPaginationUseCase.java
@@ -1,0 +1,46 @@
+package trim.api.domains.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.question.mapper.QuestionMapper;
+import trim.api.domains.question.vo.response.QuestionSummaryResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.AnswerAdaptor;
+import trim.domains.board.business.adaptor.QuestionAdaptor;
+import trim.domains.board.dao.domain.Question;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+import trim.domains.tag.business.adaptor.TagAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetAllQuestionByPaginationUseCase {
+
+    private final QuestionAdaptor questionAdaptor;
+    private final TagAdaptor tagAdaptor;
+    private final LikeAdaptor likeAdaptor;
+    private final AnswerAdaptor answerAdaptor;
+
+    public List<QuestionSummaryResponse> execute(Pageable pageable) {
+        Page<Question> questions = questionAdaptor.queryAllQuestion(pageable);
+        return questions.getContent().stream()
+                .map(this::mapToQuestionSummaryResponse)
+                .toList();
+    }
+    private QuestionSummaryResponse mapToQuestionSummaryResponse(Question question) {
+        List<String> tags = tagAdaptor.queryNamesByBoardId(question.getId());
+
+        return QuestionSummaryResponse.builder()
+                .questionResponse(QuestionMapper.INSTANCE.toQuestionResponse(question))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(question.getWriter()))
+                .likeCount(likeAdaptor.queryCountByBoard(question.getId()))
+                .answerCount(answerAdaptor.queryCountByQuestionId(question.getId()))
+                .tagList(tags)
+                .build();
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/GetAllQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/GetAllQuestionUseCase.java
@@ -2,12 +2,16 @@ package trim.api.domains.question.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.question.mapper.QuestionMapper;
 import trim.api.domains.question.vo.response.QuestionDetailResponse;
+import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.adaptor.AnswerAdaptor;
 import trim.domains.board.business.adaptor.QuestionAdaptor;
 import trim.domains.board.dao.domain.Answer;
 import trim.domains.board.dao.domain.Question;
+import trim.domains.like.business.adaptor.LikeAdaptor;
 import trim.domains.tag.business.adaptor.TagAdaptor;
 
 
@@ -22,20 +26,26 @@ public class GetAllQuestionUseCase {
     private final QuestionAdaptor questionAdaptor;
     private final AnswerAdaptor answerAdaptor;
     private final TagAdaptor tagAdaptor;
+    private final LikeAdaptor likeAdaptor;
 
-    public List<QuestionDetailResponse> execute() {
+    public List<QuestionSummaryResponse> execute() {
         List<Question> questions = questionAdaptor.queryAll();
 
         return questions.stream()
-                .map(this::mapToQuestionDetailResponse)
+                .map(this::mapToQuestionSummaryResponse)
                 .collect(Collectors.toList());
     }
 
-    private QuestionDetailResponse mapToQuestionDetailResponse(Question question) {
-        List<Answer> answers = answerAdaptor.queryByQuestionId(question.getId());
+    private QuestionSummaryResponse mapToQuestionSummaryResponse(Question question) {
         List<String> tags = tagAdaptor.queryNamesByBoardId(question.getId());
 
-        return QuestionDetailResponse.of(question, answers, tags);
+        return QuestionSummaryResponse.builder()
+                .questionResponse(QuestionMapper.INSTANCE.toQuestionResponse(question))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(question.getWriter()))
+                .likeCount(likeAdaptor.queryCountByBoard(question.getId()))
+                .answerCount(answerAdaptor.queryCountByQuestionId(question.getId()))
+                .tagList(tags)
+                .build();
     }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/request/QuestionRequest.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/request/QuestionRequest.java
@@ -2,6 +2,9 @@ package trim.api.domains.question.vo.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.yaml.snakeyaml.util.EnumUtils;
+import trim.common.interfaces.KeyedEnum;
+import trim.domains.board.dao.domain.MajorType;
 import trim.domains.board.dto.QuestionDto;
 
 import java.util.ArrayList;
@@ -12,6 +15,7 @@ import java.util.List;
 public class QuestionRequest {
     private final String title;
     private final String content;
+    private final String majorType;
     @Builder.Default
     private final List<String> tags = new ArrayList<>();
 
@@ -19,6 +23,7 @@ public class QuestionRequest {
         return QuestionDto.builder()
                 .title(this.getTitle())
                 .content(this.getContent())
+                .majorType(EnumUtils.findEnumInsensitiveCase(MajorType.class, this.majorType))
                 .build();
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionResponse.java
@@ -3,6 +3,7 @@ package trim.api.domains.question.vo.response;
 import lombok.Builder;
 import lombok.Getter;
 import trim.api.domains.comment.vo.response.CommentResponse;
+import trim.domains.board.dao.domain.MajorType;
 import trim.domains.board.dao.domain.Question;
 import trim.domains.board.dao.domain.ResolveStatus;
 import trim.domains.comment.dao.domain.Comment;
@@ -20,4 +21,5 @@ public class QuestionResponse {
     private final String content;
     private final LocalDateTime createdAt;
     private final ResolveStatus resolveStatus;
+    private final MajorType majorType;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionResponse.java
@@ -15,8 +15,9 @@ import java.util.stream.Collectors;
 @Getter
 @Builder
 public class QuestionResponse {
-    private String title;
-    private String content;
-    private LocalDateTime createdAt;
-    private ResolveStatus resolveStatus;
+    private final Long questionId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final ResolveStatus resolveStatus;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionSummaryResponse.java
@@ -3,7 +3,12 @@ package trim.api.domains.question.vo.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import trim.api.domains.answer.vo.AnswerDetailResponse;
+import trim.api.domains.member.mapper.MemberMapper;
 import trim.api.domains.member.vo.MemberResponse;
+import trim.api.domains.question.mapper.QuestionMapper;
+import trim.domains.board.dao.domain.Answer;
+import trim.domains.board.dao.domain.Question;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,4 +24,14 @@ public class QuestionSummaryResponse {
     private final Long answerCount;
     @Builder.Default
     private final List<String> tagList = new ArrayList<>();
+
+    public static QuestionSummaryResponse of(Question question, Long answerCount, Long likeCount, List<String> tags) {
+        return QuestionSummaryResponse.builder()
+                .questionResponse(QuestionMapper.INSTANCE.toQuestionResponse(question))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(question.getWriter()))
+                .answerCount(answerCount)
+                .likeCount(likeCount)
+                .tagList(tags)
+                .build();
+    }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionSummaryResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionSummaryResponse.java
@@ -1,0 +1,22 @@
+package trim.api.domains.question.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.api.domains.member.vo.MemberResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class QuestionSummaryResponse {
+
+    private final QuestionResponse questionResponse;
+    private final MemberResponse memberResponse;
+    private final Long likeCount;
+    private final Long answerCount;
+    @Builder.Default
+    private final List<String> tagList = new ArrayList<>();
+}

--- a/Trim-Common/src/main/java/trim/common/exception/ErrorStatus.java
+++ b/Trim-Common/src/main/java/trim/common/exception/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode{
     // entity FREE_TALK (4200-4249)
     // entity ANSWER (4250-4299)
     // entity LIKE (4300-4349)
+    // entity KNOWLEDGE (4350-4399)
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/Trim-Common/src/main/java/trim/common/util/StaticValues.java
+++ b/Trim-Common/src/main/java/trim/common/util/StaticValues.java
@@ -1,0 +1,6 @@
+package trim.common.util;
+
+public class StaticValues {
+    public final static String LIKE_CREATE_STATUS = "create";
+    public final static String LIKE_REMOVE_STATUS = "remove";
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/AnswerAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/AnswerAdaptor.java
@@ -9,4 +9,6 @@ public interface AnswerAdaptor {
     Answer queryById(Long answerId);
 
     List<Answer> queryByQuestionId(Long questionId);
+
+    Long queryCountByQuestionId(Long questionId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/AnswerAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/AnswerAdaptorImpl.java
@@ -24,4 +24,9 @@ public class AnswerAdaptorImpl implements AnswerAdaptor{
     public List<Answer> queryByQuestionId(Long questionId) {
         return answerRepository.findByQuestionId(questionId);
     }
+
+    @Override
+    public Long queryCountByQuestionId(Long questionId) {
+        return answerRepository.countByQuestionId(questionId);
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/BoardAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/BoardAdaptor.java
@@ -1,0 +1,10 @@
+package trim.domains.board.business.adaptor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import trim.domains.board.dao.domain.Board;
+
+public interface BoardAdaptor {
+
+    Page<Board> queryAllBoards(Pageable pageable);
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/BoardAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/BoardAdaptorImpl.java
@@ -1,0 +1,19 @@
+package trim.domains.board.business.adaptor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import trim.common.annotation.Adaptor;
+import trim.domains.board.dao.domain.Board;
+import trim.domains.board.dao.repository.BoardRepository;
+
+@Adaptor
+@RequiredArgsConstructor
+public class BoardAdaptorImpl implements BoardAdaptor{
+
+    private final BoardRepository boardRepository;
+    @Override
+    public Page<Board> queryAllBoards(Pageable pageable) {
+        return boardRepository.findAll(pageable);
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptor.java
@@ -1,5 +1,7 @@
 package trim.domains.board.business.adaptor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import trim.domains.board.dao.domain.FreeTalk;
 import trim.domains.member.dao.domain.Member;
 
@@ -12,4 +14,6 @@ public interface FreeTalkAdaptor {
     List<FreeTalk> queryFreeTalksByWriter(Member member);
 
     List<FreeTalk> queryAllFreeTalk();
+
+    Page<FreeTalk> queryAllFreeTalk(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptorImpl.java
@@ -1,6 +1,8 @@
 package trim.domains.board.business.adaptor;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import trim.common.annotation.Adaptor;
 import trim.domains.board.dao.domain.FreeTalk;
 import trim.domains.board.dao.repository.FreeTalkRepository;
@@ -27,5 +29,10 @@ public class FreeTalkAdaptorImpl implements FreeTalkAdaptor{
     @Override
     public List<FreeTalk> queryAllFreeTalk() {
         return freeTalkRepository.findAll();
+    }
+
+    @Override
+    public Page<FreeTalk> queryAllFreeTalk(Pageable pageable) {
+        return freeTalkRepository.findAll(pageable);
     }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
@@ -1,5 +1,7 @@
 package trim.domains.board.business.adaptor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.member.dao.domain.Member;
 
@@ -12,5 +14,7 @@ public interface KnowledgeAdaptor {
     List<Knowledge> queryKnowledgeByWriter(Member member);
 
     List<Knowledge> queryAllKnowledge();
+
+    Page<Knowledge> queryAllKnowledge(Pageable pageable);
 
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
@@ -1,0 +1,15 @@
+package trim.domains.board.business.adaptor;
+
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.List;
+
+public interface KnowledgeAdaptor {
+
+    Knowledge queryKnowledgeById(Long knowledgeId);
+
+    List<Knowledge> queryKnowledgeByWriter(Member member);
+
+    List<Knowledge> queryAllKnowledge();
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
@@ -9,8 +9,6 @@ public interface KnowledgeAdaptor {
 
     Knowledge queryKnowledgeById(Long knowledgeId);
 
-    Knowledge queryKnowledgeByUuid(String knowledgeUuid);
-
     List<Knowledge> queryKnowledgeByWriter(Member member);
 
     List<Knowledge> queryAllKnowledge();

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
@@ -9,7 +9,10 @@ public interface KnowledgeAdaptor {
 
     Knowledge queryKnowledgeById(Long knowledgeId);
 
+    Knowledge queryKnowledgeByUuid(String knowledgeUuid);
+
     List<Knowledge> queryKnowledgeByWriter(Member member);
 
     List<Knowledge> queryAllKnowledge();
+
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
@@ -1,6 +1,8 @@
 package trim.domains.board.business.adaptor;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import trim.common.annotation.Adaptor;
 import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.board.dao.repository.KnowledgeRepository;
@@ -29,5 +31,10 @@ public class KnowledgeAdaptorImpl implements KnowledgeAdaptor{
     @Override
     public List<Knowledge> queryAllKnowledge() {
         return knowledgeRepository.findAll();
+    }
+
+    @Override
+    public Page<Knowledge> queryAllKnowledge(Pageable pageable) {
+        return knowledgeRepository.findAll(pageable);
     }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
@@ -1,0 +1,33 @@
+package trim.domains.board.business.adaptor;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.Adaptor;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.board.dao.repository.KnowledgeRepository;
+import trim.domains.board.exception.BoardHandler;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.List;
+
+@Adaptor
+@RequiredArgsConstructor
+public class KnowledgeAdaptorImpl implements KnowledgeAdaptor{
+
+    private final KnowledgeRepository knowledgeRepository;
+
+    @Override
+    public Knowledge queryKnowledgeById(Long knowledgeId) {
+        return knowledgeRepository.findById(knowledgeId)
+                .orElseThrow(() -> BoardHandler.KNOWLEDGE_NOT_FOUND);
+    }
+
+    @Override
+    public List<Knowledge> queryKnowledgeByWriter(Member member) {
+        return knowledgeRepository.findByWriter(member);
+    }
+
+    @Override
+    public List<Knowledge> queryAllKnowledge() {
+        return knowledgeRepository.findAll();
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
@@ -22,6 +22,12 @@ public class KnowledgeAdaptorImpl implements KnowledgeAdaptor{
     }
 
     @Override
+    public Knowledge queryKnowledgeByUuid(String knowledgeUuid) {
+        return knowledgeRepository.findByKnowledgeUuid(knowledgeUuid)
+                .orElseThrow(() -> BoardHandler.KNOWLEDGE_NOT_FOUND);
+    }
+
+    @Override
     public List<Knowledge> queryKnowledgeByWriter(Member member) {
         return knowledgeRepository.findByWriter(member);
     }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
@@ -22,12 +22,6 @@ public class KnowledgeAdaptorImpl implements KnowledgeAdaptor{
     }
 
     @Override
-    public Knowledge queryKnowledgeByUuid(String knowledgeUuid) {
-        return knowledgeRepository.findByKnowledgeUuid(knowledgeUuid)
-                .orElseThrow(() -> BoardHandler.KNOWLEDGE_NOT_FOUND);
-    }
-
-    @Override
     public List<Knowledge> queryKnowledgeByWriter(Member member) {
         return knowledgeRepository.findByWriter(member);
     }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptor.java
@@ -1,6 +1,8 @@
 package trim.domains.board.business.adaptor;
 
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import trim.domains.board.dao.domain.Question;
 
 import java.util.List;
@@ -12,4 +14,6 @@ public interface QuestionAdaptor {
     List<Question> queryByWriterUsername(String username);
 
     List<Question> queryAll();
+
+    Page<Question> queryAllQuestion(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptorImpl.java
@@ -1,6 +1,8 @@
 package trim.domains.board.business.adaptor;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import trim.common.annotation.Adaptor;
 import trim.domains.board.dao.domain.Question;
 import trim.domains.board.dao.repository.QuestionRepository;
@@ -27,5 +29,10 @@ public class QuestionAdaptorImpl implements QuestionAdaptor{
     @Override
     public List<Question> queryAll() {
         return questionRepository.findAll();
+    }
+
+    @Override
+    public Page<Question> queryAllQuestion(Pageable pageable) {
+        return questionRepository.findAll(pageable);
     }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/service/KnowledgeDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/service/KnowledgeDomainService.java
@@ -1,0 +1,13 @@
+package trim.domains.board.business.service;
+
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.board.dto.KnowledgeDto;
+import trim.domains.member.dao.domain.Member;
+
+public interface KnowledgeDomainService {
+
+    Knowledge createKnowledge(Member member, KnowledgeDto knowledgeDto);
+
+    Knowledge editKnowledge(Knowledge knowledge, KnowledgeDto knowledgeDto);
+
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/service/KnowledgeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/service/KnowledgeDomainServiceImpl.java
@@ -2,6 +2,7 @@ package trim.domains.board.business.service;
 
 import lombok.RequiredArgsConstructor;
 import trim.common.annotation.DomainService;
+import trim.domains.board.dao.domain.BoardType;
 import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.board.dao.repository.KnowledgeRepository;
 import trim.domains.board.dto.KnowledgeDto;
@@ -20,6 +21,7 @@ public class KnowledgeDomainServiceImpl implements KnowledgeDomainService{
                 .title(knowledgeDto.getTitle())
                 .content(knowledgeDto.getContent())
                 .majorType(knowledgeDto.getMajorType())
+                .boardType(BoardType.KNOWLEDGE)
                 .build();
         return knowledgeRepository.save(newKnowledge);
     }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/service/KnowledgeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/service/KnowledgeDomainServiceImpl.java
@@ -1,0 +1,32 @@
+package trim.domains.board.business.service;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.DomainService;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.board.dao.repository.KnowledgeRepository;
+import trim.domains.board.dto.KnowledgeDto;
+import trim.domains.member.dao.domain.Member;
+
+@DomainService
+@RequiredArgsConstructor
+public class KnowledgeDomainServiceImpl implements KnowledgeDomainService{
+
+    private final KnowledgeRepository knowledgeRepository;
+
+    @Override
+    public Knowledge createKnowledge(Member member, KnowledgeDto knowledgeDto) {
+        Knowledge newKnowledge = Knowledge.builder()
+                .writer(member)
+                .title(knowledgeDto.getTitle())
+                .content(knowledgeDto.getContent())
+                .majorType(knowledgeDto.getMajorType())
+                .build();
+        return knowledgeRepository.save(newKnowledge);
+    }
+
+    @Override
+    public Knowledge editKnowledge(Knowledge knowledge, KnowledgeDto knowledgeDto) {
+        knowledge.edit(knowledgeDto);
+        return knowledge;
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/business/service/QuestionDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/service/QuestionDomainServiceImpl.java
@@ -27,6 +27,7 @@ public class QuestionDomainServiceImpl implements QuestionDomainService{
                 .content(dto.getContent())
                 .boardType(BoardType.QUESTION)
                 .resolveStatus(ResolveStatus.UNRESOLVED)
+                .majorType(dto.getMajorType())
                 .writer(member)
                 .build();
         return questionRepository.save(newQuestion);

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Board.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Board.java
@@ -32,7 +32,7 @@ public abstract class Board extends BaseTimeEntity {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "board_type", nullable = false)
+    @Column(name = "board_type", nullable = false, length = 50)
     private BoardType boardType;
 
     protected void edit(String title, String content) {

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/BoardType.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/BoardType.java
@@ -9,7 +9,8 @@ import trim.common.interfaces.KeyedEnum;
 public enum BoardType implements KeyedEnum {
     ANSWER("type_answer"),
     QUESTION("type_question"),
-    FREE_TALK("type_free_talk");
+    FREE_TALK("type_free_talk"),
+    KNOWLEDGE("type_knowledge");
 
     private final String key;
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Knowledge.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Knowledge.java
@@ -1,9 +1,6 @@
 package trim.domains.board.dao.domain;
 
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,6 +17,7 @@ import trim.domains.board.dto.KnowledgeDto;
 public class Knowledge extends Board{
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MajorType majorType;
 
     public void edit(KnowledgeDto knowledgeDto) {

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Knowledge.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Knowledge.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import trim.domains.board.dto.KnowledgeDto;
 
 @Entity
 @Getter
@@ -16,8 +17,13 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @DiscriminatorValue("type_knowledge")
-public class Knowledge {
+public class Knowledge extends Board{
 
     @Enumerated(EnumType.STRING)
     private MajorType majorType;
+
+    public void edit(KnowledgeDto knowledgeDto) {
+        super.edit(knowledgeDto.getTitle(), knowledgeDto.getContent());
+        this.majorType = knowledgeDto.getMajorType();
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Knowledge.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Knowledge.java
@@ -1,0 +1,23 @@
+package trim.domains.board.dao.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DiscriminatorValue("type_knowledge")
+public class Knowledge {
+
+    @Enumerated(EnumType.STRING)
+    private MajorType majorType;
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/MajorType.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/MajorType.java
@@ -1,0 +1,47 @@
+package trim.domains.board.dao.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.common.interfaces.KeyedEnum;
+
+@Getter
+@RequiredArgsConstructor
+public enum MajorType implements KeyedEnum {
+    // Humanities & Social Sciences
+    LIBERAL_ARTS("Liberal Arts College"),
+    SOCIAL_SCIENCES("Social Sciences College"),
+    BUSINESS_ADMINISTRATION("Business Administration College"),
+    LAW("Law College"),
+    EDUCATION("Education College"),
+
+    // Natural Sciences
+    NATURAL_SCIENCES("Natural Sciences College"),
+    LIFE_SCIENCES("Life Sciences College"),
+    VETERINARY_MEDICINE("Veterinary Medicine College"),
+    PHARMACY("Pharmacy College"),
+
+    // Engineering
+    ENGINEERING("Engineering College"),
+    INFORMATION_COMMUNICATIONS("Information & Communications College"),
+    INDUSTRIAL_ENGINEERING("Industrial Engineering College"),
+
+    // Arts & Sports
+    MUSIC("Music College"),
+    FINE_ARTS("Fine Arts College"),
+    PHYSICAL_EDUCATION("Physical Education College"),
+
+    // Medical
+    MEDICINE("Medical College"),
+    DENTISTRY("Dentistry College"),
+    NURSING("Nursing College"),
+
+    // Agriculture & Marine
+    AGRICULTURAL_LIFE_SCIENCES("Agricultural & Life Sciences College"),
+    MARINE_SCIENCES("Marine Sciences College"),
+
+    // Human Ecology
+    HUMAN_ECOLOGY("Human Ecology College"),
+    HOUSING_ENVIRONMENT("Housing Environment College");
+
+    private final String key;
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Question.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Question.java
@@ -22,6 +22,9 @@ public class Question extends Board {
     @Enumerated(EnumType.STRING)
     private ResolveStatus resolveStatus;
 
+    @Enumerated(EnumType.STRING)
+    private MajorType majorType;
+
     public void edit(QuestionDto dto) {
         super.edit(dto.getTitle(), dto.getContent());
     }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Question.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Question.java
@@ -27,5 +27,6 @@ public class Question extends Board {
 
     public void edit(QuestionDto dto) {
         super.edit(dto.getTitle(), dto.getContent());
+        this.majorType = dto.getMajorType();
     }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Question.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/Question.java
@@ -23,6 +23,7 @@ public class Question extends Board {
     private ResolveStatus resolveStatus;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MajorType majorType;
 
     public void edit(QuestionDto dto) {

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/AnswerRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/AnswerRepository.java
@@ -12,4 +12,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     boolean existsByQuestionId(Long id);
 
     List<Answer> findByQuestionId(Long questionId);
+
+    Long countByQuestionId(Long questionId);
+
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/BoardRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package trim.domains.board.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trim.domains.board.dao.domain.Board;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/FreeTalkRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/FreeTalkRepository.java
@@ -1,5 +1,7 @@
 package trim.domains.board.dao.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import trim.domains.board.dao.domain.FreeTalk;
 import trim.domains.member.dao.domain.Member;
@@ -9,4 +11,6 @@ import java.util.List;
 public interface FreeTalkRepository extends JpaRepository<FreeTalk, Long> {
 
     List<FreeTalk> findByWriter(Member member);
+
+    Page<FreeTalk> findAll(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -5,7 +5,10 @@ import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.member.dao.domain.Member;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
     List<Knowledge> findByWriter(Member writer);
+
+    Optional<Knowledge> findByKnowledgeUuid(String knowledgeUuid);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -1,5 +1,7 @@
 package trim.domains.board.dao.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import trim.domains.board.dao.domain.Knowledge;
 import trim.domains.member.dao.domain.Member;
@@ -9,4 +11,6 @@ import java.util.Optional;
 
 public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
     List<Knowledge> findByWriter(Member writer);
+
+    Page<Knowledge> findAll(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -9,6 +9,4 @@ import java.util.Optional;
 
 public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
     List<Knowledge> findByWriter(Member writer);
-
-    Optional<Knowledge> findByKnowledgeUuid(String knowledgeUuid);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -1,0 +1,7 @@
+package trim.domains.board.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trim.domains.board.dao.domain.Knowledge;
+
+public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -2,6 +2,10 @@ package trim.domains.board.dao.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.List;
 
 public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
+    List<Knowledge> findByWriter(Member writer);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/QuestionRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/QuestionRepository.java
@@ -1,5 +1,7 @@
 package trim.domains.board.dao.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import trim.domains.board.dao.domain.Question;
 
@@ -7,4 +9,6 @@ import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByWriterProfileUsername(String username);
+
+    Page<Question> findAll(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dto/KnowledgeDto.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dto/KnowledgeDto.java
@@ -1,0 +1,13 @@
+package trim.domains.board.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import trim.domains.board.dao.domain.MajorType;
+
+@Data
+@Builder
+public class KnowledgeDto {
+    private String title;
+    private String content;
+    private MajorType majorType;
+}

--- a/Trim-Domain/src/main/java/trim/domains/board/dto/QuestionDto.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dto/QuestionDto.java
@@ -2,10 +2,12 @@ package trim.domains.board.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import trim.domains.board.dao.domain.MajorType;
 
 @Data
 @Builder
 public class QuestionDto {
     private final String title;
     private final String content;
+    private final MajorType majorType;
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/exception/BoardErrorStatus.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/exception/BoardErrorStatus.java
@@ -31,7 +31,11 @@ public enum BoardErrorStatus implements BaseErrorCode {
 
     // entity ANSWER (4250-4299)
     ANSWER_NOT_FOUND(NOT_FOUND, 4250, "답글을 찾을 수 없습니다."),
-    ANSWER_COULD_BE_TOUCHED_BY_ONLY_WRITER(BAD_REQUEST, 4250, "답글은 오로지 작성자에 의해 수정&삭제가 가능합니다.");
+    ANSWER_COULD_BE_TOUCHED_BY_ONLY_WRITER(BAD_REQUEST, 4250, "답글은 오로지 작성자에 의해 수정&삭제가 가능합니다."),
+
+    // entity KNOWLEDGE (4350-4399)
+    KNOWLEDGE_NOT_FOUND(NOT_FOUND, 4350, "지식 공유 글을 찾을 수 없습니다."),
+    KNOWLEDGE_COULD_BE_TOUCHED_BY_ONLY_WRITER(BAD_REQUEST, 4351, "지식 공유 글은 오로지 작성자에 의해 수정&삭제가 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/Trim-Domain/src/main/java/trim/domains/board/exception/BoardHandler.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/exception/BoardHandler.java
@@ -23,6 +23,9 @@ public class BoardHandler extends GeneralException {
   //Answer
   public static final GeneralException ANSWER_NOT_FOUND =
           new BoardHandler(BoardErrorStatus.ANSWER_NOT_FOUND);
+  //Knowledge
+  public static final GeneralException KNOWLEDGE_NOT_FOUND =
+          new BoardHandler(BoardErrorStatus.KNOWLEDGE_NOT_FOUND);
 
 
   public BoardHandler(BaseErrorCode baseErrorCode) {

--- a/Trim-Domain/src/main/java/trim/domains/comment/business/adaptor/CommentAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/comment/business/adaptor/CommentAdaptor.java
@@ -11,4 +11,6 @@ public interface CommentAdaptor {
 
     List<Comment> queryAllByBoardId(Long boardId);
 
+    Long queryCountByBoardId(Long boardId);
+
 }

--- a/Trim-Domain/src/main/java/trim/domains/comment/business/adaptor/CommentAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/comment/business/adaptor/CommentAdaptorImpl.java
@@ -26,4 +26,9 @@ public class CommentAdaptorImpl implements CommentAdaptor{
         return commentRepository.findByBoardId(boardId);
     }
 
+    @Override
+    public Long queryCountByBoardId(Long boardId) {
+        return commentRepository.countByBoardId(boardId);
+    }
+
 }

--- a/Trim-Domain/src/main/java/trim/domains/comment/dao/repository/CommentRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/comment/dao/repository/CommentRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByBoardId(Long boardId);
+
+    Long countByBoardId(Long boardId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptor.java
@@ -4,5 +4,4 @@ public interface LikeAdaptor {
 
     Long queryCountByBoard(Long boardId);
 
-    boolean queryExist(Long boardId, Long memberId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptor.java
@@ -1,0 +1,8 @@
+package trim.domains.like.business.adaptor;
+
+public interface LikeAdaptor {
+
+    Long queryCountByBoard(Long boardId);
+
+    boolean queryExist(Long boardId, Long memberId);
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptorImpl.java
@@ -16,8 +16,4 @@ public class LikeAdaptorImpl implements LikeAdaptor{
         return likeRepository.countByBoardId(boardId);
     }
 
-    @Override
-    public boolean queryExist(Long boardId, Long memberId) {
-        return likeRepository.existsByBoardIdAndMemberId(boardId, memberId);
-    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/adaptor/LikeAdaptorImpl.java
@@ -1,0 +1,23 @@
+package trim.domains.like.business.adaptor;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.Adaptor;
+import trim.domains.like.dao.repository.LikeRepository;
+
+@Adaptor
+@RequiredArgsConstructor
+public class LikeAdaptorImpl implements LikeAdaptor{
+
+    private final LikeRepository likeRepository;
+
+
+    @Override
+    public Long queryCountByBoard(Long boardId) {
+        return likeRepository.countByBoardId(boardId);
+    }
+
+    @Override
+    public boolean queryExist(Long boardId, Long memberId) {
+        return likeRepository.existsByBoardIdAndMemberId(boardId, memberId);
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainService.java
@@ -8,5 +8,7 @@ public interface LikeDomainService {
 
     void removeLike(Long likeId);
 
+    void removeLikeByBoardAndMember(Long boardId, Long memberId);
+
     void removeAllLikeByBoard(Long boardId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainService.java
@@ -1,0 +1,12 @@
+package trim.domains.like.business.service;
+
+import trim.domains.like.dao.entity.Like;
+
+public interface LikeDomainService {
+
+    Like createLike(Long boardId, Long memberId);
+
+    void removeLike(Long likeId);
+
+    void removeAllLikeByBoard(Long boardId);
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainServiceImpl.java
@@ -1,0 +1,32 @@
+package trim.domains.like.business.service;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.DomainService;
+import trim.domains.like.dao.entity.Like;
+import trim.domains.like.dao.repository.LikeRepository;
+
+@DomainService
+@RequiredArgsConstructor
+public class LikeDomainServiceImpl implements LikeDomainService{
+
+    private final LikeRepository likeRepository;
+
+    @Override
+    public Like createLike(Long boardId, Long memberId) {
+        Like newLike = Like.builder()
+                .boardId(boardId)
+                .memberId(memberId)
+                .build();
+        return likeRepository.save(newLike);
+    }
+
+    @Override
+    public void removeLike(Long likeId) {
+        likeRepository.deleteById(likeId);
+    }
+
+    @Override
+    public void removeAllLikeByBoard(Long boardId) {
+        likeRepository.deleteAllByBoardId(boardId);
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/service/LikeDomainServiceImpl.java
@@ -26,6 +26,11 @@ public class LikeDomainServiceImpl implements LikeDomainService{
     }
 
     @Override
+    public void removeLikeByBoardAndMember(Long boardId, Long memberId) {
+        likeRepository.deleteByBoardIdAndMemberId(boardId, memberId);
+    }
+
+    @Override
     public void removeAllLikeByBoard(Long boardId) {
         likeRepository.deleteAllByBoardId(boardId);
     }

--- a/Trim-Domain/src/main/java/trim/domains/like/business/validator/LikeValidator.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/validator/LikeValidator.java
@@ -1,0 +1,6 @@
+package trim.domains.like.business.validator;
+
+public interface LikeValidator {
+
+    boolean isExist(Long boardId, Long memberId);
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/business/validator/LikeValidatorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/business/validator/LikeValidatorImpl.java
@@ -1,0 +1,16 @@
+package trim.domains.like.business.validator;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.DomainValidator;
+import trim.domains.like.dao.repository.LikeRepository;
+
+@DomainValidator
+@RequiredArgsConstructor
+public class LikeValidatorImpl implements LikeValidator{
+
+    private final LikeRepository likeRepository;
+    @Override
+    public boolean isExist(Long boardId, Long memberId) {
+        return likeRepository.existsByBoardIdAndMemberId(boardId, memberId);
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/dao/entity/Like.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/dao/entity/Like.java
@@ -12,6 +12,7 @@ import trim.domains.member.dao.domain.Member;
 
 @Entity
 @Getter
+@Table(name = "likes")
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/Trim-Domain/src/main/java/trim/domains/like/dao/entity/Like.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/dao/entity/Like.java
@@ -1,0 +1,28 @@
+package trim.domains.like.dao.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import trim.common.model.BaseTimeEntity;
+import trim.domains.board.dao.domain.Board;
+import trim.domains.member.dao.domain.Member;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Like extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    private Long memberId;
+
+    private Long boardId;
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/dao/repository/LikeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/dao/repository/LikeRepository.java
@@ -4,4 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import trim.domains.like.dao.entity.Like;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    Long countByBoardId(Long boardId);
+
+    boolean existsByBoardIdAndMemberId(Long boardId, Long memberId);
+
+    void deleteAllByBoardId(Long boardId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/like/dao/repository/LikeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/dao/repository/LikeRepository.java
@@ -9,4 +9,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByBoardIdAndMemberId(Long boardId, Long memberId);
 
     void deleteAllByBoardId(Long boardId);
+
+    void deleteByBoardIdAndMemberId(Long boardId, Long memberId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/like/dao/repository/LikeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/dao/repository/LikeRepository.java
@@ -1,0 +1,7 @@
+package trim.domains.like.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trim.domains.like.dao.entity.Like;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+}

--- a/Trim-Domain/src/main/java/trim/domains/like/exception/LikeErrorStatus.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/exception/LikeErrorStatus.java
@@ -1,37 +1,24 @@
-package trim.common.exception;
+package trim.domains.like.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import trim.common.annotation.ExplainError;
+import trim.common.exception.BaseErrorCode;
+import trim.common.exception.Reason;
 
 import java.lang.reflect.Field;
 import java.util.Objects;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorStatus implements BaseErrorCode{
+public enum LikeErrorStatus implements BaseErrorCode {
 
-    // 서버 오류
-    @ExplainError("500번대 알수없는 오류입니다. 서버 관리자에게 문의 주세요")
-    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 관리자에게 문의 바랍니다."),
-    @ExplainError("인증이 필요없는 api입니다.")
-    _UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR(INTERNAL_SERVER_ERROR, 5001, "서버 에러, 로그인이 필요없는 요청입니다."),
-    _ASSIGNABLE_PARAMETER(BAD_REQUEST, 5002, "인증타입이 잘못되어 할당이 불가능합니다."),
-
-    // 일반적인 요청 오류
-    _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
-    _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
-    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다.");
-
-    // entity MEMBER (4050-4099)
-    // entity QUESTION (4100-4149)
-    // entity COMMENT (4150-4199)
-    // entity FREE_TALK (4200-4249)
-    // entity ANSWER (4250-4299)
     // entity LIKE (4300-4349)
+    LIKE_ERROR(BAD_REQUEST, 4300, "좋아요 임시 에러");
+
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/Trim-Domain/src/main/java/trim/domains/like/exception/LikeHandler.java
+++ b/Trim-Domain/src/main/java/trim/domains/like/exception/LikeHandler.java
@@ -1,0 +1,9 @@
+package trim.domains.like.exception;
+
+import trim.common.exception.GeneralException;
+
+public class LikeHandler extends GeneralException {
+    public LikeHandler(LikeErrorStatus likeErrorStatus) {
+        super(likeErrorStatus);
+    }
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
> 게시글 관련 api를 프론트에서 사용 가능하도록 구체화함.
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/18
- 좋아요 기능 구현
- 질문과 지식 공유 글에 전공 추가
- 지식 공유 게시글 추가
- 페이지네이션을 통한 조회 추가
- 메인페이지에서 사용할 조회 api 추가

## 동작 확인

너무 많아서 생략.
