### PR TITLE
[Feat/#14] badge and relations entity 

### DIFF
--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
@@ -25,7 +25,7 @@ public class Badge {
 
     private String badgeTitle;
 
-    private int goalCount;
+    private int goal;
 
 
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
@@ -1,0 +1,31 @@
+package trim.domains.badge.dao.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@Table(name = "badge")
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Badge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "badge_id")
+    private Long id;
+
+    @Column(name = "next_badge_id")
+    private Long nextBadgeId;
+
+    private String badgeTitle;
+
+    private int goalCount;
+
+
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/repository/BadgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/repository/BadgeRepository.java
@@ -1,0 +1,7 @@
+package trim.domains.badge.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trim.domains.badge.dao.entity.Badge;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+}

--- a/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
@@ -1,0 +1,39 @@
+package trim.domains.mission.dao.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.member.dao.domain.Member;
+
+@Entity
+@Getter
+@Table(name = "mission")
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id")
+    private Badge badge;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MissionStatus missionStatus;
+
+    private int goalCount;
+
+}

--- a/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/MissionStatus.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/MissionStatus.java
@@ -1,0 +1,12 @@
+package trim.domains.mission.dao.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.common.interfaces.KeyedEnum;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionStatus implements KeyedEnum {
+    SUCCESS("SUCCESS"), IN_PROGRESS("IN_PROGRESS");
+    private final String key;
+}

--- a/Trim-Domain/src/main/java/trim/domains/mission/dao/repository/MissionRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/dao/repository/MissionRepository.java
@@ -1,0 +1,7 @@
+package trim.domains.mission.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trim.domains.mission.dao.entity.Mission;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
> badge와 관련된 데이터를 설계하고 프로젝트에 엔티티를 생성합니다.
## 📝 작업 내용
- https://github.com/trim-project/trim-back-mm/issues/14

뱃지와 관련된 로직은 아래와 같습니다.
1. DataInitialize을 통해서 배지는 미리 생성(이때 필요한 값은 다음 배지값, 배지 이름, 목표값)
2. 멤버를 생성하면 mission엔티티로 배지와 연결
3. mission의 카운트값과 배지의 목표치가 동일하면 다음 미션 생성(배지연결)
4. 조회는 미션을 통해서 자신이 목표치를 완성한 미션을 통해 필터링
