### PR TITLE
[Feat/#21] badge business logic

### DIFF
--- a/Trim-Common/src/main/java/trim/common/exception/ErrorStatus.java
+++ b/Trim-Common/src/main/java/trim/common/exception/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode{
     // entity LIKE (4300-4349)
     // entity KNOWLEDGE (4350-4399)
     // entity MISSION (4400-4449)
+    // entity BADGE (4450-4499)
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/Trim-Domain/src/main/java/trim/common/init/DataInitialize.java
+++ b/Trim-Domain/src/main/java/trim/common/init/DataInitialize.java
@@ -4,14 +4,65 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.badge.dao.entity.BadgeContent;
+import trim.domains.badge.dao.repository.BadgeRepository;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @Transactional
 @RequiredArgsConstructor
 public class DataInitialize {
 
+    private final BadgeRepository badgeRepository;
+
     @PostConstruct
     public void setUpBadge() {
+        List<Badge> saveBadgeList = new ArrayList<>();
+        //WRITE_QUESTION
+        for (int i = 1; i <= 10; i++) {
+            saveBadgeList.add(
+                    Badge.builder()
+                            .badgeTitle("write question" + i)
+                            .badgeContent(BadgeContent.WRITE_QUESTION)
+                            .goal(i * 4)
+                            .build()
+            );
+        }
+        //WRITE_ANSWER
+        for (int i = 1; i <= 10; i++) {
+            saveBadgeList.add(
+                    Badge.builder()
+                            .badgeTitle("write answer" + i)
+                            .badgeContent(BadgeContent.WRITE_ANSWER)
+                            .goal(i * 5)
+                            .build()
+            );
+        }
+        //WRITE_KNOWLEDGE
+        for (int i = 1; i <= 10; i++) {
+            saveBadgeList.add(
+                    Badge.builder()
+                            .badgeTitle("write knowledge" + i)
+                            .badgeContent(BadgeContent.WRITE_KNOWLEDGE)
+                            .goal(i * 5)
+                            .build()
+            );
+        }
+
+        //WRITE_FREE_TALK
+        for (int i = 1; i <= 10; i++) {
+            saveBadgeList.add(
+                    Badge.builder()
+                            .badgeTitle("write free_talk" + i)
+                            .badgeContent(BadgeContent.WRITE_FREE_TALK)
+                            .goal(i * 5)
+                            .build()
+            );
+        }
+
 
     }
 }

--- a/Trim-Domain/src/main/java/trim/common/init/DataInitialize.java
+++ b/Trim-Domain/src/main/java/trim/common/init/DataInitialize.java
@@ -27,7 +27,8 @@ public class DataInitialize {
                     Badge.builder()
                             .badgeTitle("write question" + i)
                             .badgeContent(BadgeContent.WRITE_QUESTION)
-                            .goal(i * 4)
+                            .goal(i * 5)
+                            .level(i)
                             .build()
             );
         }
@@ -37,7 +38,8 @@ public class DataInitialize {
                     Badge.builder()
                             .badgeTitle("write answer" + i)
                             .badgeContent(BadgeContent.WRITE_ANSWER)
-                            .goal(i * 5)
+                            .goal(i * 7)
+                            .level(i)
                             .build()
             );
         }
@@ -48,6 +50,7 @@ public class DataInitialize {
                             .badgeTitle("write knowledge" + i)
                             .badgeContent(BadgeContent.WRITE_KNOWLEDGE)
                             .goal(i * 5)
+                            .level(i)
                             .build()
             );
         }
@@ -59,10 +62,24 @@ public class DataInitialize {
                             .badgeTitle("write free_talk" + i)
                             .badgeContent(BadgeContent.WRITE_FREE_TALK)
                             .goal(i * 5)
+                            .level(i)
                             .build()
             );
         }
-
-
+        //WRITE_COMMENT
+        for (int i = 1; i <= 10; i++) {
+            saveBadgeList.add(
+                    Badge.builder()
+                            .badgeTitle("write comment" + i)
+                            .badgeContent(BadgeContent.WRITE_COMMENT)
+                            .goal(i * 10)
+                            .level(i)
+                            .build()
+            );
+        }
+        //TODO GET_LIKE
+        //TODO GET_ADOPTED
+        //TODO PARTICIPATE_SURVEY
+        badgeRepository.saveAll(saveBadgeList);
     }
 }

--- a/Trim-Domain/src/main/java/trim/common/init/DataInitialize.java
+++ b/Trim-Domain/src/main/java/trim/common/init/DataInitialize.java
@@ -1,0 +1,17 @@
+package trim.common.init;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class DataInitialize {
+
+    @PostConstruct
+    public void setUpBadge() {
+
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptor.java
@@ -1,0 +1,4 @@
+package trim.domains.badge.business.adaptor;
+
+public interface BadgeAdaptor {
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptor.java
@@ -1,4 +1,15 @@
 package trim.domains.badge.business.adaptor;
 
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.List;
+
 public interface BadgeAdaptor {
+
+    List<Badge> queryAllBadge();
+
+    Badge queryById(Long badgeId);
+
+    List<Badge> queryCompletedBadgesByMember(Member member);
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptorImpl.java
@@ -1,0 +1,12 @@
+package trim.domains.badge.business.adaptor;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.Adaptor;
+import trim.domains.badge.dao.repository.BadgeRepository;
+
+@Adaptor
+@RequiredArgsConstructor
+public class BadgeAdaptorImpl implements BadgeAdaptor{
+
+    private final BadgeRepository badgeRepository;
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/adaptor/BadgeAdaptorImpl.java
@@ -2,11 +2,32 @@ package trim.domains.badge.business.adaptor;
 
 import lombok.RequiredArgsConstructor;
 import trim.common.annotation.Adaptor;
+import trim.domains.badge.dao.entity.Badge;
 import trim.domains.badge.dao.repository.BadgeRepository;
+import trim.domains.badge.exception.BadgeHandler;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.List;
 
 @Adaptor
 @RequiredArgsConstructor
 public class BadgeAdaptorImpl implements BadgeAdaptor{
 
     private final BadgeRepository badgeRepository;
+
+    @Override
+    public List<Badge> queryAllBadge() {
+        return badgeRepository.findAll();
+    }
+
+    @Override
+    public Badge queryById(Long badgeId) {
+        return badgeRepository.findById(badgeId)
+                .orElseThrow(() -> BadgeHandler.NOT_FOUND);
+    }
+
+    @Override
+    public List<Badge> queryCompletedBadgesByMember(Member member) {
+        return badgeRepository.findBadgesByMember(member);
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainService.java
@@ -6,6 +6,4 @@ import trim.domains.badge.dao.entity.BadgeContent;
 public interface BadgeDomainService {
 
     Badge createBadge(String title, BadgeContent badgeContent, int goal);
-
-    void addNextBadge(Badge badge, Long nextBadgeId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainService.java
@@ -1,0 +1,10 @@
+package trim.domains.badge.business.service;
+
+import trim.domains.badge.dao.entity.Badge;
+
+public interface BadgeDomainService {
+
+    Badge createBadge(String title, int goal);
+
+    void addNextBadge(Badge badge, Long nextBadgeId);
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainService.java
@@ -1,10 +1,11 @@
 package trim.domains.badge.business.service;
 
 import trim.domains.badge.dao.entity.Badge;
+import trim.domains.badge.dao.entity.BadgeContent;
 
 public interface BadgeDomainService {
 
-    Badge createBadge(String title, int goal);
+    Badge createBadge(String title, BadgeContent badgeContent, int goal);
 
     void addNextBadge(Badge badge, Long nextBadgeId);
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainServiceImpl.java
@@ -2,6 +2,8 @@ package trim.domains.badge.business.service;
 
 import lombok.RequiredArgsConstructor;
 import trim.common.annotation.DomainService;
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.badge.dao.entity.BadgeContent;
 import trim.domains.badge.dao.repository.BadgeRepository;
 
 @DomainService
@@ -9,4 +11,19 @@ import trim.domains.badge.dao.repository.BadgeRepository;
 public class BadgeDomainServiceImpl implements BadgeDomainService{
 
     private final BadgeRepository badgeRepository;
+
+    @Override
+    public Badge createBadge(String title, BadgeContent badgeContent, int goal) {
+        Badge newBadge = Badge.builder()
+                .badgeTitle(title)
+                .badgeContent(badgeContent)
+                .goal(goal)
+                .build();
+        return badgeRepository.save(newBadge);
+    }
+
+    @Override
+    public void addNextBadge(Badge badge, Long nextBadgeId) {
+        badge.addNextBadge(nextBadgeId);
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainServiceImpl.java
@@ -21,9 +21,4 @@ public class BadgeDomainServiceImpl implements BadgeDomainService{
                 .build();
         return badgeRepository.save(newBadge);
     }
-
-    @Override
-    public void addNextBadge(Badge badge, Long nextBadgeId) {
-        badge.addNextBadge(nextBadgeId);
-    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/business/service/BadgeDomainServiceImpl.java
@@ -1,0 +1,12 @@
+package trim.domains.badge.business.service;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.DomainService;
+import trim.domains.badge.dao.repository.BadgeRepository;
+
+@DomainService
+@RequiredArgsConstructor
+public class BadgeDomainServiceImpl implements BadgeDomainService{
+
+    private final BadgeRepository badgeRepository;
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
@@ -31,4 +31,7 @@ public class Badge {
     @Column(nullable = false)
     private BadgeContent badgeContent;
 
+    public void addNextBadge(Long nextBadgeId) {
+        this.nextBadgeId = nextBadgeId;
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
@@ -20,8 +20,7 @@ public class Badge {
     @Column(name = "badge_id")
     private Long id;
 
-    @Column(name = "next_badge_id")
-    private Long nextBadgeId;
+    private int level;
 
     private String badgeTitle;
 
@@ -31,7 +30,4 @@ public class Badge {
     @Column(nullable = false)
     private BadgeContent badgeContent;
 
-    public void addNextBadge(Long nextBadgeId) {
-        this.nextBadgeId = nextBadgeId;
-    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/Badge.java
@@ -27,5 +27,8 @@ public class Badge {
 
     private int goal;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BadgeContent badgeContent;
 
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/BadgeContent.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/entity/BadgeContent.java
@@ -1,0 +1,21 @@
+package trim.domains.badge.dao.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import trim.common.interfaces.KeyedEnum;
+
+@Getter
+@RequiredArgsConstructor
+public enum BadgeContent implements KeyedEnum {
+    WRITE_QUESTION("WRITE_QUESTION"),
+    WRITE_ANSWER("WRITE_ANSWER"),
+    WRITE_KNOWLEDGE("WRITE_KNOWLEDGE"),
+    WRITE_FREE_TALK("WRITE_FREE_TALK"),
+    WRITE_COMMENT("WRITE_COMMENT"),
+    GET_LIKE("GET_LIKE"),
+    GET_ADOPTED("GET_ADOPTED"),
+    PARTICIPATE_SURVEY("PARTICIPATE_SURVEY");
+
+
+    private final String key;
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/dao/repository/BadgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/dao/repository/BadgeRepository.java
@@ -1,7 +1,15 @@
 package trim.domains.badge.dao.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import trim.domains.badge.dao.entity.Badge;
+import trim.domains.member.dao.domain.Member;
+
+import java.util.List;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
+    @Query("SELECT DISTINCT m.badge FROM Mission m " +
+            "WHERE m.member = :member")
+    List<Badge> findBadgesByMember(@Param("member") Member member);
 }

--- a/Trim-Domain/src/main/java/trim/domains/badge/exception/BadgeErrorStatus.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/exception/BadgeErrorStatus.java
@@ -1,0 +1,48 @@
+package trim.domains.badge.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import trim.common.annotation.ExplainError;
+import trim.common.exception.BaseErrorCode;
+import trim.common.exception.Reason;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+public enum BadgeErrorStatus implements BaseErrorCode{
+    // entity BADGE (4450-4499)
+    BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, 4450, "해당 배지는 조회할 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getMessage();
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/badge/exception/BadgeHandler.java
+++ b/Trim-Domain/src/main/java/trim/domains/badge/exception/BadgeHandler.java
@@ -1,0 +1,13 @@
+package trim.domains.badge.exception;
+
+import trim.common.exception.BaseErrorCode;
+import trim.common.exception.GeneralException;
+
+public class BadgeHandler extends GeneralException {
+
+    public static final GeneralException NOT_FOUND =
+            new BadgeHandler(BadgeErrorStatus.BADGE_NOT_FOUND);
+    public BadgeHandler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainService.java
@@ -8,7 +8,5 @@ public interface MissionDomainService {
 
     Mission createMission(Badge badge, Member member);
 
-    void missionClear(Mission mission);
-
     void countUp(Mission mission);
 }

--- a/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainService.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainService.java
@@ -1,0 +1,14 @@
+package trim.domains.mission.business.service;
+
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.member.dao.domain.Member;
+import trim.domains.mission.dao.entity.Mission;
+
+public interface MissionDomainService {
+
+    Mission createMission(Badge badge, Member member);
+
+    void missionClear(Mission mission);
+
+    void countUp(Mission mission);
+}

--- a/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainServiceImpl.java
@@ -1,0 +1,34 @@
+package trim.domains.mission.business.service;
+
+import lombok.RequiredArgsConstructor;
+import trim.common.annotation.DomainService;
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.member.dao.domain.Member;
+import trim.domains.mission.dao.entity.Mission;
+import trim.domains.mission.dao.repository.MissionRepository;
+
+@DomainService
+@RequiredArgsConstructor
+public class MissionDomainServiceImpl implements MissionDomainService{
+
+    private final MissionRepository missionRepository;
+
+    @Override
+    public Mission createMission(Badge badge, Member member) {
+        Mission newMission = Mission.builder()
+                .badge(badge)
+                .member(member)
+                .build();
+        return missionRepository.save(newMission);
+    }
+
+    @Override
+    public void missionClear(Mission mission) {
+        mission.complete();
+    }
+
+    @Override
+    public void countUp(Mission mission) {
+        mission.countUp();
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainServiceImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/business/service/MissionDomainServiceImpl.java
@@ -23,11 +23,6 @@ public class MissionDomainServiceImpl implements MissionDomainService{
     }
 
     @Override
-    public void missionClear(Mission mission) {
-        mission.complete();
-    }
-
-    @Override
     public void countUp(Mission mission) {
         mission.countUp();
     }

--- a/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
@@ -5,6 +5,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import trim.domains.badge.dao.entity.Badge;
 import trim.domains.member.dao.domain.Member;
+import trim.domains.mission.exception.MissionHandler;
 
 @Entity
 @Getter
@@ -37,12 +38,14 @@ public class Mission {
 
 
     public void complete() {
-        this.missionStatus = MissionStatus.SUCCESS;
+        if (this.badge.getGoal() == this.goalCount) {
+            this.missionStatus = MissionStatus.SUCCESS;
+        }
     }
 
     public void countUp() {
         if (this.badge.getGoal() > this.goalCount) {
-            throw new RuntimeException("enough count");
+            throw MissionHandler.ALREADY_CLEAR;
         }
         this.goalCount++;
     }

--- a/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
@@ -38,15 +38,18 @@ public class Mission {
 
 
     public void complete() {
-        if (this.badge.getGoal() == this.goalCount) {
-            this.missionStatus = MissionStatus.SUCCESS;
-        }
+        this.missionStatus = MissionStatus.SUCCESS;
     }
 
     public void countUp() {
-        if (this.badge.getGoal() > this.goalCount) {
+        if (this.goalCount >= this.badge.getGoal()) {
             throw MissionHandler.ALREADY_CLEAR;
         }
+
         this.goalCount++;
+
+        if (this.goalCount == this.badge.getGoal()) {
+            complete();
+        }
     }
 }

--- a/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/dao/entity/Mission.java
@@ -1,10 +1,7 @@
 package trim.domains.mission.dao.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import trim.domains.badge.dao.entity.Badge;
 import trim.domains.member.dao.domain.Member;
@@ -30,10 +27,23 @@ public class Mission {
     @JoinColumn(name = "badge_id")
     private Badge badge;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private MissionStatus missionStatus;
+    private MissionStatus missionStatus = MissionStatus.IN_PROGRESS;
 
-    private int goalCount;
+    @Builder.Default
+    private int goalCount = 0;
 
+
+    public void complete() {
+        this.missionStatus = MissionStatus.SUCCESS;
+    }
+
+    public void countUp() {
+        if (this.badge.getGoal() > this.goalCount) {
+            throw new RuntimeException("enough count");
+        }
+        this.goalCount++;
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/mission/exception/MissionErrorStatus.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/exception/MissionErrorStatus.java
@@ -1,9 +1,11 @@
-package trim.common.exception;
+package trim.domains.mission.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import trim.common.annotation.ExplainError;
+import trim.common.exception.BaseErrorCode;
+import trim.common.exception.Reason;
 
 import java.lang.reflect.Field;
 import java.util.Objects;
@@ -12,33 +14,14 @@ import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorStatus implements BaseErrorCode{
-
-    // 서버 오류
-    @ExplainError("500번대 알수없는 오류입니다. 서버 관리자에게 문의 주세요")
-    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 관리자에게 문의 바랍니다."),
-    @ExplainError("인증이 필요없는 api입니다.")
-    _UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR(INTERNAL_SERVER_ERROR, 5001, "서버 에러, 로그인이 필요없는 요청입니다."),
-    _ASSIGNABLE_PARAMETER(BAD_REQUEST, 5002, "인증타입이 잘못되어 할당이 불가능합니다."),
-
-    // 일반적인 요청 오류
-    _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
-    _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
-    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다.");
-
-    // entity MEMBER (4050-4099)
-    // entity QUESTION (4100-4149)
-    // entity COMMENT (4150-4199)
-    // entity FREE_TALK (4200-4249)
-    // entity ANSWER (4250-4299)
-    // entity LIKE (4300-4349)
-    // entity KNOWLEDGE (4350-4399)
+public enum MissionErrorStatus implements BaseErrorCode {
     // entity MISSION (4400-4449)
+    MISSION_NOT_FOUND(NOT_FOUND, 4400, "해당 미션을 찾을 수 없습니다."),
+    MISSION_ALREADY_CLEAR(BAD_REQUEST, 4401, "미션을 이미 클리어하였습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;
     private final String message;
-
 
     @Override
     public Reason getReason() {

--- a/Trim-Domain/src/main/java/trim/domains/mission/exception/MissionHandler.java
+++ b/Trim-Domain/src/main/java/trim/domains/mission/exception/MissionHandler.java
@@ -1,0 +1,16 @@
+package trim.domains.mission.exception;
+
+import trim.common.exception.BaseErrorCode;
+import trim.common.exception.GeneralException;
+
+public class MissionHandler extends GeneralException {
+
+    public static final GeneralException NOT_FOUND =
+            new MissionHandler(MissionErrorStatus.MISSION_NOT_FOUND);
+    public static final GeneralException ALREADY_CLEAR =
+            new MissionHandler(MissionErrorStatus.MISSION_ALREADY_CLEAR);
+
+    public MissionHandler(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
> badge의 기본적인 비즈니스 로직을 작성합니다.(in Domain module)
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/21
- badge 데이터 이닛 세팅
- 유저의 미션 생성
- 미션 목표 카운트 로직 작성
- 모든 뱃지 조회
- 멤버의 미션을 통한 배지 조회