### PR TITLE
[Feat/#26] initialize apis for boards and member

### DIFF
--- a/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
@@ -1,0 +1,26 @@
+package trim.api.common.init;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.member.service.CreateMemberDummyDataUseCase;
+
+@Tag(name = "[더미 데이터 입력]")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dummy")
+public class DataInitializeApiController {
+
+    private final CreateMemberDummyDataUseCase createMemberDummyDataUseCase;
+
+    @Operation(summary = "member 더미 데이터를 입력합니다. memberCount는 입력할 데이터 개수입니다.")
+    @PostMapping("/members")
+    public ApiResponseDto<Boolean> createMemberDummyData(@RequestParam int memberCount) {
+        return ApiResponseDto.onSuccess(createMemberDummyDataUseCase.execute(memberCount));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.answer.service.CreateAnswerDummyDataUseCase;
 import trim.api.domains.freetalk.service.CreateFreeTalkDummyDataUseCase;
 import trim.api.domains.knowledge.service.CreateKnowledgeDummyDataUseCase;
 import trim.api.domains.member.service.CreateMemberDummyDataUseCase;
@@ -20,6 +21,7 @@ public class DataInitializeApiController {
     private final CreateQuestionDummyDataUseCase createQuestionDummyDataUseCase;
     private final CreateFreeTalkDummyDataUseCase createFreeTalkDummyDataUseCase;
     private final CreateKnowledgeDummyDataUseCase createKnowledgeDummyDataUseCase;
+    private final CreateAnswerDummyDataUseCase createAnswerDummyDataUseCase;
 
     @Operation(summary = "member 더미 데이터를 입력합니다. member count 는 입력할 데이터 개수입니다.")
     @PostMapping("/members")
@@ -49,5 +51,14 @@ public class DataInitializeApiController {
             @PathVariable Long memberId,
             @RequestParam int knowledgeCount) {
         return ApiResponseDto.onSuccess(createKnowledgeDummyDataUseCase.execute(memberId, knowledgeCount));
+    }
+
+    @Operation(summary = "answer 더미 데이터를 입력합니다. answer count 는 입력할 데이터 개수입니다.")
+    @PostMapping("/answers/questions/{questionId}/members/{memberId}")
+    public ApiResponseDto<Boolean> createAnswerDummyData(
+            @PathVariable Long questionId,
+            @PathVariable Long memberId,
+            @RequestParam int knowledgeCount) {
+        return ApiResponseDto.onSuccess(createAnswerDummyDataUseCase.execute(questionId, memberId, knowledgeCount));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
@@ -3,12 +3,10 @@ package trim.api.common.init;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.member.service.CreateMemberDummyDataUseCase;
+import trim.api.domains.member.service.CreateQuestionDummyDataUseCase;
 
 @Tag(name = "[더미 데이터 입력]")
 @RestController
@@ -17,10 +15,19 @@ import trim.api.domains.member.service.CreateMemberDummyDataUseCase;
 public class DataInitializeApiController {
 
     private final CreateMemberDummyDataUseCase createMemberDummyDataUseCase;
+    private final CreateQuestionDummyDataUseCase createQuestionDummyDataUseCase;
 
-    @Operation(summary = "member 더미 데이터를 입력합니다. memberCount는 입력할 데이터 개수입니다.")
+    @Operation(summary = "member 더미 데이터를 입력합니다. member count 는 입력할 데이터 개수입니다.")
     @PostMapping("/members")
     public ApiResponseDto<Boolean> createMemberDummyData(@RequestParam int memberCount) {
         return ApiResponseDto.onSuccess(createMemberDummyDataUseCase.execute(memberCount));
+    }
+
+    @Operation(summary = "question 더미 데이터를 입력합니다. question count 는 입력할 데이터 개수입니다.")
+    @PostMapping("/questions/members/{memberId}")
+    public ApiResponseDto<Boolean> createQuestionDummyData(
+            @PathVariable Long memberId,
+            @RequestParam int questionCount) {
+        return ApiResponseDto.onSuccess(createQuestionDummyDataUseCase.execute(memberId, questionCount));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.freetalk.service.CreateFreeTalkDummyDataUseCase;
 import trim.api.domains.member.service.CreateMemberDummyDataUseCase;
 import trim.api.domains.member.service.CreateQuestionDummyDataUseCase;
 
@@ -16,6 +17,7 @@ public class DataInitializeApiController {
 
     private final CreateMemberDummyDataUseCase createMemberDummyDataUseCase;
     private final CreateQuestionDummyDataUseCase createQuestionDummyDataUseCase;
+    private final CreateFreeTalkDummyDataUseCase createFreeTalkDummyDataUseCase;
 
     @Operation(summary = "member 더미 데이터를 입력합니다. member count 는 입력할 데이터 개수입니다.")
     @PostMapping("/members")
@@ -29,5 +31,13 @@ public class DataInitializeApiController {
             @PathVariable Long memberId,
             @RequestParam int questionCount) {
         return ApiResponseDto.onSuccess(createQuestionDummyDataUseCase.execute(memberId, questionCount));
+    }
+
+    @Operation(summary = "freeTalk 더미 데이터를 입력합니다. freeTalk count 는 입력할 데이터 개수입니다.")
+    @PostMapping("/free-talks/members/{memberId}")
+    public ApiResponseDto<Boolean> createFreeTalkDummyData(
+            @PathVariable Long memberId,
+            @RequestParam int freeTalkCount) {
+        return ApiResponseDto.onSuccess(createFreeTalkDummyDataUseCase.execute(memberId, freeTalkCount));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.freetalk.service.CreateFreeTalkDummyDataUseCase;
+import trim.api.domains.knowledge.service.CreateKnowledgeDummyDataUseCase;
 import trim.api.domains.member.service.CreateMemberDummyDataUseCase;
 import trim.api.domains.member.service.CreateQuestionDummyDataUseCase;
 
@@ -18,6 +19,7 @@ public class DataInitializeApiController {
     private final CreateMemberDummyDataUseCase createMemberDummyDataUseCase;
     private final CreateQuestionDummyDataUseCase createQuestionDummyDataUseCase;
     private final CreateFreeTalkDummyDataUseCase createFreeTalkDummyDataUseCase;
+    private final CreateKnowledgeDummyDataUseCase createKnowledgeDummyDataUseCase;
 
     @Operation(summary = "member 더미 데이터를 입력합니다. member count 는 입력할 데이터 개수입니다.")
     @PostMapping("/members")
@@ -39,5 +41,13 @@ public class DataInitializeApiController {
             @PathVariable Long memberId,
             @RequestParam int freeTalkCount) {
         return ApiResponseDto.onSuccess(createFreeTalkDummyDataUseCase.execute(memberId, freeTalkCount));
+    }
+
+    @Operation(summary = "knowledge 더미 데이터를 입력합니다. knowledge count 는 입력할 데이터 개수입니다.")
+    @PostMapping("/knowledge/members/{memberId}")
+    public ApiResponseDto<Boolean> createKnowledgeDummyData(
+            @PathVariable Long memberId,
+            @RequestParam int knowledgeCount) {
+        return ApiResponseDto.onSuccess(createKnowledgeDummyDataUseCase.execute(memberId, knowledgeCount));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/answer/service/CreateAnswerDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/service/CreateAnswerDummyDataUseCase.java
@@ -1,0 +1,30 @@
+package trim.api.domains.answer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.answer.vo.AnswerRequest;
+import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
+import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.common.annotation.UseCase;
+import trim.domains.board.dao.domain.MajorType;
+
+import java.util.List;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateAnswerDummyDataUseCase {
+
+    private final WriteAnswerUseCase writeAnswerUseCase;
+
+    public Boolean execute(Long questionId, Long memberId, int knowledgeCount) {
+        for (int i = 0; i < knowledgeCount; i++) {
+            AnswerRequest request = AnswerRequest.builder()
+                    .title("title of answer" + i + "by" + memberId)
+                    .content("content of answer" + i + "by" + memberId)
+                    .build();
+            writeAnswerUseCase.execute(questionId, memberId, request);
+        }
+        return true;
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -32,7 +32,7 @@ public class FreeTalkApiController {
     @PostMapping("/members/{memberId}")
     public ApiResponseDto<Long> writeFreeTalk(@PathVariable Long memberId,
                                               @RequestBody FreeTalkRequest request) {
-        return ApiResponseDto.onSuccess(writeFreeTalkUseCase.execute(request, memberId));
+        return ApiResponseDto.onSuccess(writeFreeTalkUseCase.execute(memberId, request));
     }
 
     @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 조회 형식은 요약본입니다.")

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/CreateFreeTalkDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/CreateFreeTalkDummyDataUseCase.java
@@ -1,0 +1,25 @@
+package trim.api.domains.freetalk.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
+import trim.common.annotation.UseCase;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateFreeTalkDummyDataUseCase {
+
+    private final WriteFreeTalkUseCase writeFreeTalkUseCase;
+
+    public Boolean execute(Long memberId, int freeTalkCount) {
+        for (int i = 0; i < freeTalkCount; i++) {
+            FreeTalkRequest request = FreeTalkRequest.builder()
+                    .title("title of FreeTalk" + i + "by" + memberId)
+                    .content("content of FreeTalk" + i + "by" + memberId)
+                    .build();
+            writeFreeTalkUseCase.execute(memberId, request);
+        }
+        return true;
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/WriteFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/WriteFreeTalkUseCase.java
@@ -16,7 +16,7 @@ public class WriteFreeTalkUseCase {
     private final FreeTalkDomainService freeTalkDomainService;
     private final MemberAdaptor memberAdaptor;
 
-    public Long execute(FreeTalkRequest request, Long memberId) {
+    public Long execute(Long memberId, FreeTalkRequest request) {
         Member member = memberAdaptor.queryMember(memberId);
         return freeTalkDomainService.createFreeTalk(member, request.from()).getId();
     }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/CreateKnowledgeDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/CreateKnowledgeDummyDataUseCase.java
@@ -1,0 +1,31 @@
+package trim.api.domains.knowledge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
+import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.common.annotation.UseCase;
+import trim.domains.board.dao.domain.MajorType;
+
+import java.util.List;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateKnowledgeDummyDataUseCase {
+
+    private final WriteKnowledgeUseCase writeKnowledgeUseCase;
+
+    public Boolean execute(Long memberId, int knowledgeCount) {
+        for (int i = 0; i < knowledgeCount; i++) {
+            KnowledgeRequest request = KnowledgeRequest.builder()
+                    .title("title of Knowledge" + i + "by" + memberId)
+                    .content("content of Knowledge" + i + "by" + memberId)
+                    .majorType(MajorType.getRandomMajor().getKey())
+                    .tags(List.of("knowledge1", "knowledge2"))
+                    .build();
+            writeKnowledgeUseCase.execute(memberId, request);
+        }
+        return true;
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/member/service/CreateMemberDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/service/CreateMemberDummyDataUseCase.java
@@ -1,0 +1,45 @@
+package trim.api.domains.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.member.vo.MemberRequest;
+import trim.common.annotation.UseCase;
+import trim.common.util.EnumConvertUtil;
+import trim.domains.badge.business.adaptor.BadgeAdaptor;
+import trim.domains.badge.dao.entity.Badge;
+import trim.domains.member.business.service.MemberDomainService;
+import trim.domains.member.dao.domain.Member;
+import trim.domains.member.dao.domain.Profile;
+import trim.domains.member.dao.domain.Role;
+import trim.domains.member.dao.domain.SocialType;
+import trim.domains.mission.business.service.MissionDomainService;
+import trim.domains.mission.dao.entity.MissionStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+import static trim.domains.mission.dao.entity.MissionStatus.IN_PROGRESS;
+import static trim.domains.mission.dao.entity.MissionStatus.LOCKED;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateMemberDummyDataUseCase {
+
+    private final RegisterMemberUseCase registerMemberUseCase;
+
+    public boolean execute(int memberCount) {
+        for (int i = 0; i < memberCount; i++) {
+            MemberRequest request = MemberRequest.builder()
+                    .email(UUID.randomUUID().toString() + "@trim.com")
+                    .role(Role.USER.getKey())
+                    .socialType(SocialType.TRIM.getKey())
+                    .username(UUID.randomUUID().toString() + i)
+                    .nickname(UUID.randomUUID().toString() + i)
+                    .build();
+            registerMemberUseCase.execute(request);
+        }
+        return true;
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/member/service/CreateMemberDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/service/CreateMemberDummyDataUseCase.java
@@ -23,7 +23,6 @@ import static trim.domains.mission.dao.entity.MissionStatus.IN_PROGRESS;
 import static trim.domains.mission.dao.entity.MissionStatus.LOCKED;
 
 @UseCase
-@Transactional
 @RequiredArgsConstructor
 public class CreateMemberDummyDataUseCase {
 

--- a/Trim-Api/src/main/java/trim/api/domains/member/service/CreateQuestionDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/service/CreateQuestionDummyDataUseCase.java
@@ -1,0 +1,29 @@
+package trim.api.domains.member.service;
+
+import lombok.RequiredArgsConstructor;
+import trim.api.domains.question.service.WriteQuestionUseCase;
+import trim.api.domains.question.vo.request.QuestionRequest;
+import trim.common.annotation.UseCase;
+import trim.domains.board.dao.domain.MajorType;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateQuestionDummyDataUseCase {
+
+    private final WriteQuestionUseCase writeQuestionUseCase;
+
+    public Boolean execute(Long memberId, int questionCount) {
+        for (int i = 0; i < questionCount; i++) {
+            QuestionRequest request = QuestionRequest.builder()
+                    .content("content" + i)
+                    .majorType(MajorType.getRandomMajor().getKey())
+                    .title("title" + i)
+                    .tags(List.of("dummy1", "dummy2", "dummy3"))
+                    .build();
+            writeQuestionUseCase.execute(memberId, request);
+        }
+        return true;
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/member/service/CreateQuestionDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/service/CreateQuestionDummyDataUseCase.java
@@ -17,9 +17,9 @@ public class CreateQuestionDummyDataUseCase {
     public Boolean execute(Long memberId, int questionCount) {
         for (int i = 0; i < questionCount; i++) {
             QuestionRequest request = QuestionRequest.builder()
-                    .content("content" + i)
+                    .content("content Question" + i +"by" + memberId)
                     .majorType(MajorType.getRandomMajor().getKey())
-                    .title("title" + i)
+                    .title("title Question" + i +"by" + memberId)
                     .tags(List.of("dummy1", "dummy2", "dummy3"))
                     .build();
             writeQuestionUseCase.execute(memberId, request);

--- a/Trim-Api/src/main/java/trim/api/domains/member/vo/MemberRequest.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/vo/MemberRequest.java
@@ -1,9 +1,11 @@
 package trim.api.domains.member.vo;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@Builder
 @RequiredArgsConstructor
 public class MemberRequest {
 

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RequestMapping("/api/questions")
 public class QuestionApiController {
 
-    private final CreateQuestionUseCase createQuestionUseCase;
+    private final WriteQuestionUseCase writeQuestionUseCase;
     private final EditQuestionUseCase editQuestionUseCase;
     private final GetSpecificQuestionUseCase getSpecificQuestionUseCase;
     private final GetAllQuestionUseCase getAllQuestionUseCase;
@@ -30,7 +30,7 @@ public class QuestionApiController {
     @Operation(summary = "질문 게시판 작성 메서드입니다.")
     @PostMapping("/members/{memberId}")
     public ApiResponseDto<Long> createQuestion(@PathVariable Long memberId, @RequestBody QuestionRequest request) {
-        return ApiResponseDto.onSuccess(createQuestionUseCase.execute(memberId, request));
+        return ApiResponseDto.onSuccess(writeQuestionUseCase.execute(memberId, request));
 
     }
 

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/WriteQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/WriteQuestionUseCase.java
@@ -27,7 +27,6 @@ public class WriteQuestionUseCase {
 
     public Long execute(Long memberId, QuestionRequest questionRequest) {
         Member writer = memberAdaptor.queryMember(memberId);
-        log.info("major type = {}", questionRequest.getMajorType());
         Question question = questionDomainService.writeQuestion(
                 writer,
                 QuestionMapper.INSTANCE.toQuestionDto(questionRequest)

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/WriteQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/WriteQuestionUseCase.java
@@ -6,14 +6,12 @@ import org.springframework.transaction.annotation.Transactional;
 import trim.api.domains.question.mapper.QuestionMapper;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.common.annotation.UseCase;
-import trim.domains.badge.dao.entity.BadgeContent;
 import trim.domains.board.business.service.QuestionDomainService;
 import trim.domains.board.dao.domain.Question;
 import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
 import trim.domains.mission.business.adaptor.MissionAdaptor;
 import trim.domains.mission.business.service.MissionDomainService;
-import trim.domains.mission.dao.entity.Mission;
 import trim.domains.tag.business.service.TagDomainService;
 
 
@@ -21,15 +19,12 @@ import trim.domains.tag.business.service.TagDomainService;
 @UseCase
 @Transactional
 @RequiredArgsConstructor
-public class CreateQuestionUseCase {
+public class WriteQuestionUseCase {
 
     private final MemberAdaptor memberAdaptor;
     private final QuestionDomainService questionDomainService;
     private final TagDomainService tagDomainService;
-    private final MissionAdaptor missionAdaptor;
-    private final MissionDomainService missionDomainService;
 
-    @Transactional
     public Long execute(Long memberId, QuestionRequest questionRequest) {
         Member writer = memberAdaptor.queryMember(memberId);
         log.info("major type = {}", questionRequest.getMajorType());

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/MajorType.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/MajorType.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import trim.common.interfaces.KeyedEnum;
 
+import java.util.Random;
+
 @Getter
 @RequiredArgsConstructor
 public enum MajorType implements KeyedEnum {
@@ -44,4 +46,11 @@ public enum MajorType implements KeyedEnum {
     HOUSING_ENVIRONMENT("Housing Environment College");
 
     private final String key;
+
+    private static final Random RANDOM = new Random();
+    private static final MajorType[] VALUES = values();
+
+    public static MajorType getRandomMajor() {
+        return VALUES[RANDOM.nextInt(VALUES.length)];
+    }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
> 프론트 엔드가 사용할 수 있는 더미데이터 api들을 생성(게시글 + 멤버)
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/26
