### PR TITLE
[Feat/#28] board

### DIFF
--- a/Trim-Api/src/main/java/trim/api/common/util/PageUtil.java
+++ b/Trim-Api/src/main/java/trim/api/common/util/PageUtil.java
@@ -1,0 +1,7 @@
+package trim.api.common.util;
+
+import org.springframework.data.domain.Sort;
+
+public class PageUtil {
+    public final static Sort LATEST_SORTING = Sort.by("createdAt").descending();
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -14,8 +14,11 @@ import trim.api.domains.freetalk.service.WriteFreeTalkUseCase;
 import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
 import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
 import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
+import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 
 import java.util.List;
+
+import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
 
 @Tag(name = "[자유 게시판]")
 @RequiredArgsConstructor
@@ -27,6 +30,7 @@ public class FreeTalkApiController {
     private final GetAllFreeTalkUseCase getAllFreeTalkUseCase;
     private final GetSpecificFreeTalkUseCase getSpecificFreeTalkUseCase;
     private final GetAllFreeTalkByPaginationUseCase getAllFreeTalkByPaginationUseCase;
+    private final GetHotFreeTalksUseCase getHotFreeTalksUseCase;
 
     @Operation(summary = "자유 게시판 글을 작성합니다.")
     @PostMapping("/members/{memberId}")
@@ -54,5 +58,12 @@ public class FreeTalkApiController {
             @RequestParam int pageSize) {
         Pageable pageable = PageRequest.of(currentPage, pageSize);
         return ApiResponseDto.onSuccess(getAllFreeTalkByPaginationUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "자유 게시판의 인기 게시글 6개를 조회합니다.")
+    @GetMapping("/hot-issue")
+    public ApiResponseDto<List<QuestionSummaryResponse>> getHotQuestions() {
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
+        return ApiResponseDto.onSuccess(getHotFreeTalksUseCase.execute(pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -7,10 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.domains.freetalk.service.GetAllFreeTalkByPaginationUseCase;
-import trim.api.domains.freetalk.service.GetAllFreeTalkUseCase;
-import trim.api.domains.freetalk.service.GetSpecificFreeTalkUseCase;
-import trim.api.domains.freetalk.service.WriteFreeTalkUseCase;
+import trim.api.domains.freetalk.service.*;
 import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
 import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
 import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
@@ -62,7 +59,7 @@ public class FreeTalkApiController {
 
     @Operation(summary = "자유 게시판의 인기 게시글 6개를 조회합니다.")
     @GetMapping("/hot-issue")
-    public ApiResponseDto<List<QuestionSummaryResponse>> getHotQuestions() {
+    public ApiResponseDto<List<FreeTalkSummaryResponse>> getHotFreeTalks() {
         Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
         return ApiResponseDto.onSuccess(getHotFreeTalksUseCase.execute(pageable));
     }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetHotFreeTalksUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetHotFreeTalksUseCase.java
@@ -18,14 +18,13 @@ import java.util.List;
 @UseCase
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class GetAllFreeTalkByPaginationUseCase {
-
+public class GetHotFreeTalksUseCase {
     private final FreeTalkAdaptor freeTalkAdaptor;
     private final CommentAdaptor commentAdaptor;
     private final LikeAdaptor likeAdaptor;
 
     public List<FreeTalkSummaryResponse> execute(Pageable pageable) {
-        Page<FreeTalk> freeTalks = freeTalkAdaptor.queryAllFreeTalk(pageable);
+        Page<FreeTalk> freeTalks = freeTalkAdaptor.queryHotFreeTalks(pageable);
         return freeTalks.getContent().stream()
                 .map(this::mapToFreeTalkSummaryResponse)
                 .toList();

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -7,15 +7,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.domains.knowledge.service.GetAllKnowledgeByPaginationUseCase;
-import trim.api.domains.knowledge.service.GetAllKnowledgeUseCase;
-import trim.api.domains.knowledge.service.GetSpecificKnowledgeUseCase;
-import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
+import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
+import trim.api.domains.knowledge.service.*;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
 import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
 
 import java.util.List;
+
+import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
 
 @Tag(name = "[지식 공유]")
 @RestController
@@ -27,6 +27,7 @@ public class KnowledgeApiController {
     private final GetAllKnowledgeUseCase getAllKnowledgeUseCase;
     private final GetSpecificKnowledgeUseCase getSpecificKnowledgeUseCase;
     private final GetAllKnowledgeByPaginationUseCase getAllKnowledgeByPaginationUseCase;
+    private final GetHotKnowledgeUseCase getHotKnowledgeUseCase;
 
     @Operation(summary = "지식 공유 게시글을 작성합니다.")
     @PostMapping("/members/{memberId}")
@@ -55,5 +56,12 @@ public class KnowledgeApiController {
     ) {
         Pageable pageable = PageRequest.of(currentPage, pageSize);
         return ApiResponseDto.onSuccess(getAllKnowledgeByPaginationUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "지식 공유 게시판의 인기 게시글 6개를 조회합니다.")
+    @GetMapping("/hot-issue")
+    public ApiResponseDto<List<KnowledgeSummaryResponse>> getHotKnowledge() {
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
+        return ApiResponseDto.onSuccess(getHotKnowledgeUseCase.execute(pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetHotKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetHotKnowledgeUseCase.java
@@ -1,0 +1,40 @@
+package trim.api.domains.knowledge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.KnowledgeAdaptor;
+import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.comment.business.adaptor.CommentAdaptor;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+import trim.domains.tag.business.adaptor.TagAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetHotKnowledgeUseCase {
+
+    private final KnowledgeAdaptor knowledgeAdaptor;
+    private final CommentAdaptor commentAdaptor;
+    private final LikeAdaptor likeAdaptor;
+    private final TagAdaptor tagAdaptor;
+
+    public List<KnowledgeSummaryResponse> execute(Pageable pageable) {
+        Page<Knowledge> knowledgePage = knowledgeAdaptor.queryHotKnowledge(pageable);
+        return knowledgePage.getContent().stream()
+                .map(knowledge ->
+                        KnowledgeSummaryResponse.of(
+                                knowledge,
+                                knowledge.getWriter(),
+                                likeAdaptor.queryCountByBoard(knowledge.getId()),
+                                commentAdaptor.queryCountByBoardId(knowledge.getId()),
+                                tagAdaptor.queryNamesByBoardId(knowledge.getId())))
+                .toList();
+
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -73,7 +73,7 @@ public class QuestionApiController {
     @Operation(summary = "질문 게시판의 인기 게시글 6개를 조회합니다.")
     @GetMapping("/hot-issue")
     public ApiResponseDto<List<QuestionSummaryResponse>> getHotQuestions() {
-        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT, PageUtil.LATEST_SORTING);
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
         return ApiResponseDto.onSuccess(getHotQuestionsUseCase.execute(pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -7,13 +7,17 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
+import trim.api.common.util.PageUtil;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionDetailResponse;
 import trim.api.domains.question.service.*;
 import trim.api.domains.question.vo.response.QuestionSummaryResponse;
+import trim.common.util.StaticValues;
 
 
 import java.util.List;
+
+import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
 
 @Tag(name = "[질문 게시판]")
 @RequiredArgsConstructor
@@ -62,6 +66,13 @@ public class QuestionApiController {
             @RequestParam int pageSize
     ) {
         Pageable pageable = PageRequest.of(currentPage, pageSize);
+        return ApiResponseDto.onSuccess(getAllQuestionByPaginationUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "질문 게시판의 인기 게시글 6개를 조회합니다.")
+    @GetMapping("/hot-issue")
+    public ApiResponseDto<List<QuestionSummaryResponse>> getHotIssueQuestion() {
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT, PageUtil.LATEST_SORTING);
         return ApiResponseDto.onSuccess(getAllQuestionByPaginationUseCase.execute(pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -30,6 +30,7 @@ public class QuestionApiController {
     private final GetSpecificQuestionUseCase getSpecificQuestionUseCase;
     private final GetAllQuestionUseCase getAllQuestionUseCase;
     private final GetAllQuestionByPaginationUseCase getAllQuestionByPaginationUseCase;
+    private final GetHotQuestionsUseCase getHotQuestionsUseCase;
 
     @Operation(summary = "질문 게시판 작성 메서드입니다.")
     @PostMapping("/members/{memberId}")
@@ -71,8 +72,8 @@ public class QuestionApiController {
 
     @Operation(summary = "질문 게시판의 인기 게시글 6개를 조회합니다.")
     @GetMapping("/hot-issue")
-    public ApiResponseDto<List<QuestionSummaryResponse>> getHotIssueQuestion() {
+    public ApiResponseDto<List<QuestionSummaryResponse>> getHotQuestions() {
         Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT, PageUtil.LATEST_SORTING);
-        return ApiResponseDto.onSuccess(getAllQuestionByPaginationUseCase.execute(pageable));
+        return ApiResponseDto.onSuccess(getHotQuestionsUseCase.execute(pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/GetHotQuestionsUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/GetHotQuestionsUseCase.java
@@ -1,0 +1,47 @@
+package trim.api.domains.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.member.mapper.MemberMapper;
+import trim.api.domains.question.mapper.QuestionMapper;
+import trim.api.domains.question.vo.response.QuestionSummaryResponse;
+import trim.common.annotation.UseCase;
+import trim.domains.board.business.adaptor.AnswerAdaptor;
+import trim.domains.board.business.adaptor.QuestionAdaptor;
+import trim.domains.board.dao.domain.Question;
+import trim.domains.like.business.adaptor.LikeAdaptor;
+import trim.domains.tag.business.adaptor.TagAdaptor;
+
+import java.util.List;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetHotQuestionsUseCase {
+
+    private final QuestionAdaptor questionAdaptor;
+    private final TagAdaptor tagAdaptor;
+    private final LikeAdaptor likeAdaptor;
+    private final AnswerAdaptor answerAdaptor;
+
+
+    public List<QuestionSummaryResponse> execute(Pageable pageable) {
+        Page<Question> questions = questionAdaptor.queryHotQuestions(pageable);
+        return questions.getContent().stream()
+                .map(this::mapToQuestionSummaryResponse)
+                .toList();
+    }
+    private QuestionSummaryResponse mapToQuestionSummaryResponse(Question question) {
+        List<String> tags = tagAdaptor.queryNamesByBoardId(question.getId());
+
+        return QuestionSummaryResponse.builder()
+                .questionResponse(QuestionMapper.INSTANCE.toQuestionResponse(question))
+                .memberResponse(MemberMapper.INSTANCE.toMemberResponse(question.getWriter()))
+                .likeCount(likeAdaptor.queryCountByBoard(question.getId()))
+                .answerCount(answerAdaptor.queryCountByQuestionId(question.getId()))
+                .tagList(tags)
+                .build();
+    }
+}

--- a/Trim-Common/src/main/java/trim/common/util/StaticValues.java
+++ b/Trim-Common/src/main/java/trim/common/util/StaticValues.java
@@ -4,4 +4,5 @@ public class StaticValues {
     public final static String LIKE_CREATE_STATUS = "create";
     public final static String LIKE_REMOVE_STATUS = "remove";
     public final static String CORS_FRONT_LOCAL_PATH = "http://localhost:3000";
+    public static final int HOT_ISSUE_COUNT = 6;
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptor.java
@@ -3,6 +3,7 @@ package trim.domains.board.business.adaptor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import trim.domains.board.dao.domain.FreeTalk;
+import trim.domains.board.dao.domain.Question;
 import trim.domains.member.dao.domain.Member;
 
 import java.util.List;
@@ -16,4 +17,6 @@ public interface FreeTalkAdaptor {
     List<FreeTalk> queryAllFreeTalk();
 
     Page<FreeTalk> queryAllFreeTalk(Pageable pageable);
+
+    Page<FreeTalk> queryHotFreeTalks(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/FreeTalkAdaptorImpl.java
@@ -35,4 +35,9 @@ public class FreeTalkAdaptorImpl implements FreeTalkAdaptor{
     public Page<FreeTalk> queryAllFreeTalk(Pageable pageable) {
         return freeTalkRepository.findAll(pageable);
     }
+
+    @Override
+    public Page<FreeTalk> queryHotFreeTalks(Pageable pageable) {
+        return freeTalkRepository.findHotFreeTalks(pageable);
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptor.java
@@ -17,4 +17,6 @@ public interface KnowledgeAdaptor {
 
     Page<Knowledge> queryAllKnowledge(Pageable pageable);
 
+    Page<Knowledge> queryHotKnowledge(Pageable pageable);
+
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/KnowledgeAdaptorImpl.java
@@ -37,4 +37,9 @@ public class KnowledgeAdaptorImpl implements KnowledgeAdaptor{
     public Page<Knowledge> queryAllKnowledge(Pageable pageable) {
         return knowledgeRepository.findAll(pageable);
     }
+
+    @Override
+    public Page<Knowledge> queryHotKnowledge(Pageable pageable) {
+        return knowledgeRepository.findHotKnowledge(pageable);
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptor.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptor.java
@@ -16,4 +16,6 @@ public interface QuestionAdaptor {
     List<Question> queryAll();
 
     Page<Question> queryAllQuestion(Pageable pageable);
+
+    Page<Question> queryHotQuestions(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/business/adaptor/QuestionAdaptorImpl.java
@@ -35,4 +35,9 @@ public class QuestionAdaptorImpl implements QuestionAdaptor{
     public Page<Question> queryAllQuestion(Pageable pageable) {
         return questionRepository.findAll(pageable);
     }
+
+    @Override
+    public Page<Question> queryHotQuestions(Pageable pageable) {
+        return questionRepository.findHotQuestions(pageable);
+    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/FreeTalkRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/FreeTalkRepository.java
@@ -3,7 +3,9 @@ package trim.domains.board.dao.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import trim.domains.board.dao.domain.FreeTalk;
+import trim.domains.board.dao.domain.Question;
 import trim.domains.member.dao.domain.Member;
 
 import java.util.List;
@@ -13,4 +15,12 @@ public interface FreeTalkRepository extends JpaRepository<FreeTalk, Long> {
     List<FreeTalk> findByWriter(Member member);
 
     Page<FreeTalk> findAll(Pageable pageable);
+
+    @Query("""
+    SELECT f FROM FreeTalk f 
+    LEFT JOIN Like l ON f.id = l.boardId 
+    GROUP BY f.id
+    ORDER BY COUNT(l) DESC, f.createdAt DESC
+    """)
+    Page<FreeTalk> findHotFreeTalks(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -17,10 +17,10 @@ public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
     Page<Knowledge> findAll(Pageable pageable);
 
     @Query("""
-            SELECT q FROM Question q 
-            LEFT JOIN Like l ON q.id = l.boardId 
-            GROUP BY q.id
-            ORDER BY COUNT(l) DESC, q.createdAt DESC
+            SELECT k FROM Knowledge k 
+            LEFT JOIN Like l ON k.id = l.boardId 
+            GROUP BY k.id
+            ORDER BY COUNT(l) DESC, k.createdAt DESC
             """)
     Page<Knowledge> findHotKnowledge(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -15,4 +15,12 @@ public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
     List<Knowledge> findByWriter(Member writer);
 
     Page<Knowledge> findAll(Pageable pageable);
+
+    @Query("""
+            SELECT q FROM Question q 
+            LEFT JOIN Like l ON q.id = l.boardId 
+            GROUP BY q.id
+            ORDER BY COUNT(l) DESC, q.createdAt DESC
+            """)
+    Page<Knowledge> findHotKnowledge(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/KnowledgeRepository.java
@@ -3,7 +3,9 @@ package trim.domains.board.dao.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import trim.domains.board.dao.domain.Knowledge;
+import trim.domains.board.dao.domain.Question;
 import trim.domains.member.dao.domain.Member;
 
 import java.util.List;

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/QuestionRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/QuestionRepository.java
@@ -3,6 +3,7 @@ package trim.domains.board.dao.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import trim.domains.board.dao.domain.Question;
 
 import java.util.List;
@@ -11,4 +12,12 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByWriterProfileUsername(String username);
 
     Page<Question> findAll(Pageable pageable);
+
+    @Query("""
+    SELECT q FROM Question q 
+    LEFT JOIN (SELECT l.boardId, COUNT(l) AS likeCount FROM Like l GROUP BY l.boardId) likes 
+    ON q.id = likes.boardId
+    ORDER BY COALESCE(likes.likeCount, 0) DESC, q.createdAt DESC
+    """)
+    Page<Question> findHotQuestions(Pageable pageable);
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/repository/QuestionRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/repository/QuestionRepository.java
@@ -15,9 +15,9 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("""
     SELECT q FROM Question q 
-    LEFT JOIN (SELECT l.boardId, COUNT(l) AS likeCount FROM Like l GROUP BY l.boardId) likes 
-    ON q.id = likes.boardId
-    ORDER BY COALESCE(likes.likeCount, 0) DESC, q.createdAt DESC
+    LEFT JOIN Like l ON q.id = l.boardId 
+    GROUP BY q.id
+    ORDER BY COUNT(l) DESC, q.createdAt DESC
     """)
     Page<Question> findHotQuestions(Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
> 인기 게시글(랜딩페이지, 게시글 조회 상단 인기 게시글 추천) 조회 api 생성
## 📝 작업 내용
- https://github.com/trim-project/trim-back-mm/issues/28

## 동작 확인

> 질문, 자유, 지식공유 모두 인기순(좋아요 개수 내림차순)으로 정렬한 것을 확인했습니다