### PR TITLE
[Refactor/#34] insert fields (page&totalPages) for using infinite scroll

### DIFF
--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -11,6 +11,7 @@ import trim.api.common.util.PageUtil;
 import trim.api.domains.freetalk.service.*;
 import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
 import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
+import trim.api.domains.freetalk.vo.response.FreeTalkListResponse;
 import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
 import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 
@@ -51,7 +52,7 @@ public class FreeTalkApiController {
 
     @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
     @GetMapping("/page")
-    public ApiResponseDto<List<FreeTalkSummaryResponse>> getAllFreeTalkByPagination(
+    public ApiResponseDto<FreeTalkListResponse> getAllFreeTalkByPagination(
             @RequestParam(defaultValue = "0") int currentPage,
             @RequestParam int pageSize) {
         Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/GetAllFreeTalkByPaginationUseCase.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import trim.api.domains.freetalk.mapper.FreeTalkMapper;
+import trim.api.domains.freetalk.vo.response.FreeTalkListResponse;
 import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
 import trim.api.domains.member.mapper.MemberMapper;
 import trim.common.annotation.UseCase;
@@ -24,11 +25,17 @@ public class GetAllFreeTalkByPaginationUseCase {
     private final CommentAdaptor commentAdaptor;
     private final LikeAdaptor likeAdaptor;
 
-    public List<FreeTalkSummaryResponse> execute(Pageable pageable) {
+    public FreeTalkListResponse execute(Pageable pageable) {
         Page<FreeTalk> freeTalks = freeTalkAdaptor.queryAllFreeTalk(pageable);
-        return freeTalks.getContent().stream()
-                .map(this::mapToFreeTalkSummaryResponse)
-                .toList();
+
+        return FreeTalkListResponse.builder()
+                .freeTalkResponseList(
+                        freeTalks.getContent().stream()
+                                .map(this::mapToFreeTalkSummaryResponse)
+                                .toList())
+                .page(freeTalks.getNumber())
+                .totalPages(freeTalks.getTotalPages())
+                .build();
     }
 
     private FreeTalkSummaryResponse mapToFreeTalkSummaryResponse(FreeTalk freeTalk) {

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkListResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkListResponse.java
@@ -1,0 +1,18 @@
+package trim.api.domains.freetalk.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class FreeTalkListResponse {
+    @Builder.Default
+    private final List<FreeTalkSummaryResponse> freeTalkResponseList = new ArrayList<>();
+    private final int page;
+    private final int totalPages;
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -12,6 +12,7 @@ import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
 import trim.api.domains.knowledge.service.*;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
+import trim.api.domains.knowledge.vo.response.KnowledgeListResponse;
 import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
 
 import java.util.List;
@@ -51,7 +52,7 @@ public class KnowledgeApiController {
 
     @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
     @GetMapping("/page")
-    public ApiResponseDto<List<KnowledgeSummaryResponse>> getAllKnowledgeByPagination(
+    public ApiResponseDto<KnowledgeListResponse> getAllKnowledgeByPagination(
             @RequestParam(defaultValue = "0") int currentPage,
             @RequestParam int pageSize
     ) {

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeByPaginationUseCase.java
@@ -43,6 +43,5 @@ public class GetAllKnowledgeByPaginationUseCase {
                 .page(knowledgePage.getNumber())
                 .totalPages(knowledgePage.getTotalPages())
                 .build();
-
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/GetAllKnowledgeByPaginationUseCase.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
+import trim.api.domains.knowledge.vo.response.KnowledgeListResponse;
 import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.adaptor.KnowledgeAdaptor;
@@ -24,17 +25,24 @@ public class GetAllKnowledgeByPaginationUseCase {
     private final LikeAdaptor likeAdaptor;
     private final TagAdaptor tagAdaptor;
 
-    public List<KnowledgeSummaryResponse> execute(Pageable pageable) {
+    public KnowledgeListResponse execute(Pageable pageable) {
         Page<Knowledge> knowledgePage = knowledgeAdaptor.queryAllKnowledge(pageable);
-        return knowledgePage.getContent().stream()
-                .map(knowledge ->
-                        KnowledgeSummaryResponse.of(
-                                knowledge,
-                                knowledge.getWriter(),
-                                likeAdaptor.queryCountByBoard(knowledge.getId()),
-                                commentAdaptor.queryCountByBoardId(knowledge.getId()),
-                                tagAdaptor.queryNamesByBoardId(knowledge.getId())))
-                .toList();
+
+        return KnowledgeListResponse.builder()
+                .knowledgeResponseList(
+                        knowledgePage.getContent().stream()
+                                .map(knowledge ->
+                                        KnowledgeSummaryResponse.of(
+                                                knowledge,
+                                                knowledge.getWriter(),
+                                                likeAdaptor.queryCountByBoard(knowledge.getId()),
+                                                commentAdaptor.queryCountByBoardId(knowledge.getId()),
+                                                tagAdaptor.queryNamesByBoardId(knowledge.getId())))
+                                .toList()
+                )
+                .page(knowledgePage.getNumber())
+                .totalPages(knowledgePage.getTotalPages())
+                .build();
 
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeListResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeListResponse.java
@@ -1,0 +1,18 @@
+package trim.api.domains.knowledge.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class KnowledgeListResponse {
+    @Builder.Default
+    private final List<KnowledgeSummaryResponse> knowledgeResponseList = new ArrayList<>();
+    private final int page;
+    private final int totalPages;
+}

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -11,6 +11,7 @@ import trim.api.common.util.PageUtil;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionDetailResponse;
 import trim.api.domains.question.service.*;
+import trim.api.domains.question.vo.response.QuestionListResponse;
 import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 import trim.common.util.StaticValues;
 
@@ -62,7 +63,7 @@ public class QuestionApiController {
 
     @Operation(summary = "질문 게시판을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
     @GetMapping("/page")
-    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestionByPagination(
+    public ApiResponseDto<QuestionListResponse> getAllQuestionByPagination(
             @RequestParam(defaultValue = "0") int currentPage,
             @RequestParam int pageSize
     ) {

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/GetAllQuestionByPaginationUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/GetAllQuestionByPaginationUseCase.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import trim.api.domains.member.mapper.MemberMapper;
 import trim.api.domains.question.mapper.QuestionMapper;
+import trim.api.domains.question.vo.response.QuestionListResponse;
 import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.adaptor.AnswerAdaptor;
@@ -26,11 +27,17 @@ public class GetAllQuestionByPaginationUseCase {
     private final LikeAdaptor likeAdaptor;
     private final AnswerAdaptor answerAdaptor;
 
-    public List<QuestionSummaryResponse> execute(Pageable pageable) {
+    public QuestionListResponse execute(Pageable pageable) {
         Page<Question> questions = questionAdaptor.queryAllQuestion(pageable);
-        return questions.getContent().stream()
-                .map(this::mapToQuestionSummaryResponse)
-                .toList();
+        return QuestionListResponse.builder()
+                .questionResponseList(
+                        questions.getContent().stream()
+                                .map(this::mapToQuestionSummaryResponse)
+                                .toList()
+                )
+                .page(questions.getNumber())
+                .totalPages(questions.getTotalPages())
+                .build();
     }
     private QuestionSummaryResponse mapToQuestionSummaryResponse(Question question) {
         List<String> tags = tagAdaptor.queryNamesByBoardId(question.getId());

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionListResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionListResponse.java
@@ -1,0 +1,18 @@
+package trim.api.domains.question.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class QuestionListResponse {
+    @Builder.Default
+    private final List<QuestionSummaryResponse> questionResponseList = new ArrayList<>();
+    private final int page;
+    private final int totalPages;
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
> 무한스크롤을 위해 board 리스트를 조회할 때 page, totalPages 필드를 추가
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/34
- 각 게시글 별로 listResponse추가
- 컨트롤러 리턴 값 변경
- usecase에서 page와 totalPages입력