### PR TITLE
[Feat/#33] create survey relation data 

### DIFF
--- a/Trim-Domain/build.gradle
+++ b/Trim-Domain/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'mysql:mysql-connector-java:8.0.33'
+    // MongoDB 추가
+    api 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     implementation project(':Trim-Common')
     implementation project(':Trim-Infra')
@@ -18,13 +20,3 @@ test {
     useJUnitPlatform()
 }
 
-//task copyYML(type: Copy) {
-//    from "${rootProject.projectDir}/config/domain/"
-//    include '*.yml'
-//    into "${projectDir}/src/main/resources/"
-//
-//    // 대상 디렉토리가 없는 경우 생성
-//    doFirst {
-//        file("${projectDir}/src/main/resources/").mkdirs()
-//    }
-//}

--- a/Trim-Domain/src/main/java/trim/config/MongoDBConfig.java
+++ b/Trim-Domain/src/main/java/trim/config/MongoDBConfig.java
@@ -1,0 +1,26 @@
+package trim.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@RequiredArgsConstructor
+@Configuration
+public class MongoDBConfig {
+
+    private final MongoProperties mongoProperties;
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(mongoProperties.getUri());
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
+        return new MongoTemplate(mongoClient, mongoProperties.getDatabase());
+    }
+}

--- a/Trim-Domain/src/main/java/trim/config/MongoDBConfig.java
+++ b/Trim-Domain/src/main/java/trim/config/MongoDBConfig.java
@@ -7,20 +7,21 @@ import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@RequiredArgsConstructor
+@EnableMongoRepositories
 @Configuration
 public class MongoDBConfig {
 
-    private final MongoProperties mongoProperties;
-
-    @Bean
-    public MongoClient mongoClient() {
-        return MongoClients.create(mongoProperties.getUri());
-    }
-
-    @Bean
-    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
-        return new MongoTemplate(mongoClient, mongoProperties.getDatabase());
-    }
+//    private final MongoProperties mongoProperties;
+//
+//    @Bean
+//    public MongoClient mongoClient() {
+//        return MongoClients.create(mongoProperties.getUri());
+//    }
+//
+//    @Bean
+//    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
+//        return new MongoTemplate(mongoClient, mongoProperties.getDatabase());
+//    }
 }

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/AnswerStatistics.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/AnswerStatistics.java
@@ -1,0 +1,6 @@
+package trim.domains.survey.dao.entity;
+
+public class AnswerStatistics {
+    private String choiceId;  // 선택지 ID
+    private int count;
+}

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Choice.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Choice.java
@@ -1,0 +1,9 @@
+package trim.domains.survey.dao.entity;
+
+import lombok.Data;
+
+@Data
+public class Choice {
+    private String choiceId; // 선택지 ID
+    private String text; // 선택지 내용
+}

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
@@ -1,0 +1,13 @@
+package trim.domains.survey.dao.entity;
+
+import jakarta.persistence.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "survey")
+public class Survey {
+    @Id
+    private String id;
+    private String title;
+    private List<SurveyQuestion> surveyQuestionList;
+    private String createdAt;
+}

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
@@ -2,14 +2,14 @@ package trim.domains.survey.dao.entity;
 
 import jakarta.persistence.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import trim.common.model.BaseTimeEntity;
 
 import java.util.List;
 
 @Document(collection = "survey")
-public class Survey {
+public class Survey extends BaseTimeEntity {
     @Id
     private String id;
     private String title;
     private List<SurveyQuestion> surveyQuestionList;
-    private String createdAt;
 }

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
@@ -3,6 +3,8 @@ package trim.domains.survey.dao.entity;
 import jakarta.persistence.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.List;
+
 @Document(collection = "survey")
 public class Survey {
     @Id

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/Survey.java
@@ -1,11 +1,13 @@
 package trim.domains.survey.dao.entity;
 
 import jakarta.persistence.Id;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.mongodb.core.mapping.Document;
 import trim.common.model.BaseTimeEntity;
 
 import java.util.List;
 
+@SuperBuilder
 @Document(collection = "survey")
 public class Survey extends BaseTimeEntity {
     @Id

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyAnswer.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyAnswer.java
@@ -1,0 +1,16 @@
+package trim.domains.survey.dao.entity;
+
+import jakarta.persistence.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Map;
+
+@Document(collection = "survey_answer")
+public class SurveyAnswer {
+    @Id
+    private String id;
+    private String surveyId;
+    private String respondentId;        //응답자 id
+    private Map<String, Object> answers; // questionId -> 응답 값
+    private String submittedAt;
+}

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyAnswer.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyAnswer.java
@@ -1,11 +1,13 @@
 package trim.domains.survey.dao.entity;
 
 import jakarta.persistence.Id;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.mongodb.core.mapping.Document;
 import trim.common.model.BaseTimeEntity;
 
 import java.util.Map;
 
+@SuperBuilder
 @Document(collection = "survey_answer")
 public class SurveyAnswer extends BaseTimeEntity {
     @Id

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyAnswer.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyAnswer.java
@@ -2,11 +2,12 @@ package trim.domains.survey.dao.entity;
 
 import jakarta.persistence.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import trim.common.model.BaseTimeEntity;
 
 import java.util.Map;
 
 @Document(collection = "survey_answer")
-public class SurveyAnswer {
+public class SurveyAnswer extends BaseTimeEntity {
     @Id
     private String id;
     private String surveyId;

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyQuestion.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/entity/SurveyQuestion.java
@@ -1,0 +1,15 @@
+package trim.domains.survey.dao.entity;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SurveyQuestion {
+    public class Question {
+        private String questionId;
+        private String title;
+        private String type;  // "radiogroup", "checkbox", "text", "text-multiple"
+        private List<Choice> choices;  // 객관식 선택지 (주관식일 경우 null)
+    }
+}

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/repository/SurveyAnswerRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/repository/SurveyAnswerRepository.java
@@ -1,0 +1,34 @@
+package trim.domains.survey.dao.repository;
+
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+import trim.domains.survey.dao.entity.AnswerStatistics;
+import trim.domains.survey.dao.entity.SurveyAnswer;
+
+import java.util.List;
+
+@Repository
+public interface SurveyAnswerRepository extends MongoRepository<SurveyAnswer, String> {
+    // 특정 유저(respondent)의 설문 응답 조회
+    @Query("{ 'surveyId': ?0, 'respondentId': ?1 }")
+    List<SurveyAnswer> findBySurveyIdAndRespondentId(String surveyId, String respondentId);
+
+    // 특정 주관식 질문의 응답 리스트 조회
+    @Aggregation(pipeline = {
+            "{ '$match': { 'surveyId': ?0 } }",
+            "{ '$project': { '_id': 0, 'answer': '$answers.?1' } }"
+    })
+    List<String> findTextAnswersByQuestionId(String surveyId, String questionId);
+
+    // 특정 객관식 질문의 응답 통계 조회
+    @Aggregation(pipeline = {
+            "{ '$match': { 'surveyId': ?0 } }",
+            "{ '$unwind': '$answers.?1' }",  // 다중 선택을 위한 배열 분해
+            "{ '$group': { '_id': '$answers.?1', 'count': { '$sum': 1 } } }",
+            "{ '$sort': { 'count': -1 } }",
+            "{ '$project': { 'choiceId': '$_id', 'count': 1, '_id': 0 } }"  // `_id` -> `choiceId`
+    })
+    List<AnswerStatistics> findChoiceStatisticsByQuestionId(String surveyId, String questionId);
+}

--- a/Trim-Domain/src/main/java/trim/domains/survey/dao/repository/SurveyRepository.java
+++ b/Trim-Domain/src/main/java/trim/domains/survey/dao/repository/SurveyRepository.java
@@ -1,0 +1,13 @@
+package trim.domains.survey.dao.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import trim.domains.survey.dao.entity.Survey;
+
+import java.util.Optional;
+
+@Repository
+public interface SurveyRepository extends MongoRepository<Survey, String> {
+    // 특정 Survey 조회 (Survey ID 기준)
+    Optional<Survey> findById(String id);
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
> survey 기본 db 설정을 합니다. 데이터를 담을 객체 클래스와 필드를 생성하고 repository와 mongodb를 사용하기 위한 준비를 합니다.
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/33
- mongoDB 설정
- survey, surveyQuestion, choice, surveyAnswer, AnswerStatistics 생성

### 왜 NoSQL(MongoDB)를 사용하는지
설문조사에는 크게 객관식, 주관식으로 타입이 나뉘게 되는데, 이를 insert할 때도 복잡하지만 조회 특히 통계 값을 가져올 때 통일된 형식을 사용할 수 있을거란 장담을 못하였다. 따라서 json형식으로 저장하기 용이한 NoSQL을 선택. 
insert할때는 최대한 entity와 유사한 vo를 사용하고, 조회 시에는 mongoDB의 쿼리를 사용하여 원하는 값만 도출할 수 있도록 한다.

-> 장점 : 관계에 대한 설정을 고민할 필요 없어짐. 데이터 조회 시에는 연관관계에 의한 것이 아닌 필드 필터링을 통해 가져오도록한다.


## 💬 리뷰 요구사항(선택)

관계형 데이터베이스에서 이를 더 잘 구현할 수 있을까요?