### PR TITLE
[Refactor/#42] convert date type in boardresponse 

### DIFF
--- a/Trim-Api/src/main/java/trim/api/common/util/EnumMappingUtil.java
+++ b/Trim-Api/src/main/java/trim/api/common/util/EnumMappingUtil.java
@@ -21,7 +21,7 @@ public class EnumMappingUtil {
     }
 
     @Named("localDateTimeToLong")
-    static Long localDateTimeToLong(LocalDateTime createdAt) {
+    public static Long localDateTimeToLong(LocalDateTime createdAt) {
         return createdAt != null ? createdAt.toInstant(ZoneOffset.UTC).toEpochMilli() : null;
     }
 }

--- a/Trim-Api/src/main/java/trim/api/common/util/EnumMappingUtil.java
+++ b/Trim-Api/src/main/java/trim/api/common/util/EnumMappingUtil.java
@@ -5,6 +5,9 @@ import trim.common.util.EnumConvertUtil;
 import trim.domains.board.dao.domain.MajorType;
 import trim.domains.member.dao.domain.SocialType;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 public class EnumMappingUtil {
 
     @Named("stringToMajorType")
@@ -15,5 +18,10 @@ public class EnumMappingUtil {
     @Named("stringToSocialType")
     public static SocialType stringToSocialType(String socialType) {
         return EnumConvertUtil.convert(SocialType.class, socialType);
+    }
+
+    @Named("localDateTimeToLong")
+    static Long localDateTimeToLong(LocalDateTime createdAt) {
+        return createdAt != null ? createdAt.toInstant(ZoneOffset.UTC).toEpochMilli() : null;
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/answer/mapper/AnswerMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/mapper/AnswerMapper.java
@@ -4,14 +4,16 @@ import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.answer.vo.AnswerResponse;
 import trim.domains.board.dao.domain.Answer;
 
-@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder = @Builder(disableBuilder = false))
 public interface AnswerMapper {
 
     AnswerMapper INSTANCE = Mappers.getMapper(AnswerMapper.class);
 
     @Mapping(target = "questionId", source = "answer.questionId")
+    @Mapping(target = "createdAt", source = "answer.createdAt", qualifiedByName = "localDateTimeToLong")
     AnswerResponse toAnswerResponse(Answer answer);
 }

--- a/Trim-Api/src/main/java/trim/api/domains/answer/vo/AnswerResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/vo/AnswerResponse.java
@@ -11,4 +11,5 @@ public class AnswerResponse {
     private final String title;
     private final String content;
     private final Long questionId;
+    private final Long createdAt;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/mapper/FreeTalkMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/mapper/FreeTalkMapper.java
@@ -4,10 +4,11 @@ import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.freetalk.vo.response.FreeTalkResponse;
 import trim.domains.board.dao.domain.FreeTalk;
 
-@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder = @Builder(disableBuilder = false))
 public interface FreeTalkMapper {
 
     FreeTalkMapper INSTANCE = Mappers.getMapper(FreeTalkMapper.class);
@@ -15,6 +16,6 @@ public interface FreeTalkMapper {
     @Mapping(target = "freeTalkId", source = "freeTalk.id")
     @Mapping(target = "title", source = "freeTalk.title")
     @Mapping(target = "content", source = "freeTalk.content")
-    @Mapping(target = "createdAt", source = "freeTalk.createdAt")
+    @Mapping(target = "createdAt", source = "freeTalk.createdAt", qualifiedByName = "localDateTimeToLong")
     FreeTalkResponse toFreeTalkResponse(FreeTalk freeTalk);
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/vo/response/FreeTalkResponse.java
@@ -4,8 +4,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDate;
-
 @Getter
 @Builder
 @RequiredArgsConstructor
@@ -13,5 +11,5 @@ public class FreeTalkResponse {
     private final Long freeTalkId;
     private final String title;
     private final String content;
-    private final LocalDate createdAt;
+    private final Long createdAt;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/mapper/KnowledgeMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/mapper/KnowledgeMapper.java
@@ -3,20 +3,14 @@ package trim.api.domains.knowledge.mapper;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.api.domains.knowledge.vo.response.KnowledgeResponse;
-import trim.api.domains.question.vo.request.QuestionRequest;
-import trim.common.util.EnumConvertUtil;
 import trim.domains.board.dao.domain.Knowledge;
-import trim.domains.board.dao.domain.MajorType;
 import trim.domains.board.dto.KnowledgeDto;
-import trim.domains.board.dto.QuestionDto;
 
-@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder= @Builder(disableBuilder = false))
-
+@Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder = @Builder(disableBuilder = false))
 public interface KnowledgeMapper {
 
     KnowledgeMapper INSTANCE = Mappers.getMapper(KnowledgeMapper.class);
@@ -27,6 +21,6 @@ public interface KnowledgeMapper {
     @Mapping(target = "knowledgeId", source = "knowledge.id")
     @Mapping(target = "title", source = "knowledge.title")
     @Mapping(target = "content", source = "knowledge.content")
-    @Mapping(target = "createdAt", source = "knowledge.createdAt")
+    @Mapping(target = "createdAt", source = "knowledge.createdAt", qualifiedByName = "localDateTimeToLong")
     KnowledgeResponse toKnowledgeResponse(Knowledge knowledge);
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/vo/response/KnowledgeResponse.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import trim.domains.board.dao.domain.MajorType;
 
-import java.time.LocalDate;
-
 @Getter
 @Builder
 @RequiredArgsConstructor
@@ -15,6 +13,6 @@ public class KnowledgeResponse {
     private final Long knowledgeId;
     private final String title;
     private final String content;
-    private final LocalDate createdAt;
+    private final Long createdAt;
     private final MajorType majorType;
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/mapper/QuestionMapper.java
@@ -3,16 +3,12 @@ package trim.api.domains.question.mapper;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 import trim.api.common.util.EnumMappingUtil;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionResponse;
-import trim.common.util.EnumConvertUtil;
-import trim.domains.board.dao.domain.MajorType;
 import trim.domains.board.dao.domain.Question;
 import trim.domains.board.dto.QuestionDto;
-import trim.domains.member.dao.domain.SocialType;
 
 @Mapper(componentModel = "spring", uses = EnumMappingUtil.class, builder = @Builder(disableBuilder = false))
 public interface QuestionMapper {
@@ -22,7 +18,7 @@ public interface QuestionMapper {
     @Mapping(target = "questionId", source = "question.id")
     @Mapping(target = "title", source = "question.title")
     @Mapping(target = "content", source = "question.content")
-    @Mapping(target = "createdAt", source = "question.createdAt")
+    @Mapping(target = "createdAt", source = "question.createdAt", qualifiedByName = "localDateTimeToLong")
     QuestionResponse toQuestionResponse(Question question);
 
     @Mapping(target = "majorType", qualifiedByName = "stringToMajorType")

--- a/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionResponse.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/vo/response/QuestionResponse.java
@@ -2,15 +2,8 @@ package trim.api.domains.question.vo.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import trim.api.domains.comment.vo.response.CommentResponse;
 import trim.domains.board.dao.domain.MajorType;
-import trim.domains.board.dao.domain.Question;
 import trim.domains.board.dao.domain.ResolveStatus;
-import trim.domains.comment.dao.domain.Comment;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 
 @Getter
@@ -19,7 +12,7 @@ public class QuestionResponse {
     private final Long questionId;
     private final String title;
     private final String content;
-    private final LocalDateTime createdAt;
+    private final Long createdAt;
     private final ResolveStatus resolveStatus;
     private final MajorType majorType;
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
> board response의 localDateTime을 Long으로 변경
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/42
- enumMappingUtil에 createdAt을 Long으로 변환하는 메서드 추가
- 게시글 response에 타입 변경

## 동작 확인

<img width="632" alt="스크린샷 2025-03-04 오후 3 16 50" src="https://github.com/user-attachments/assets/17c83eeb-2577-43d4-be85-bb60e799be34" />
