### PR TITLE
[Refactor/#45] edit Majortype Enum & create annotation RequestParamList

### DIFF
--- a/Trim-Api/src/main/java/trim/api/common/resolver/SplitRequestParamResolver.java
+++ b/Trim-Api/src/main/java/trim/api/common/resolver/SplitRequestParamResolver.java
@@ -2,6 +2,7 @@ package trim.api.common.resolver;
 
 
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -11,6 +12,7 @@ import trim.common.annotation.RequestParamList;
 import java.util.Arrays;
 import java.util.List;
 
+@Component
 public class SplitRequestParamResolver implements HandlerMethodArgumentResolver {
 
     @Override

--- a/Trim-Api/src/main/java/trim/api/common/resolver/SplitRequestParamResolver.java
+++ b/Trim-Api/src/main/java/trim/api/common/resolver/SplitRequestParamResolver.java
@@ -1,0 +1,44 @@
+package trim.api.common.resolver;
+
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import trim.common.annotation.RequestParamList;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SplitRequestParamResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // `@SplitRequestParam`이 적용된 List<String> 파라미터인지 확인
+        return parameter.hasParameterAnnotation(RequestParamList.class)
+                && parameter.getParameterType().equals(List.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        // 어노테이션 정보 가져오기
+        RequestParamList annotation = parameter.getParameterAnnotation(RequestParamList.class);
+        if (annotation == null) {
+            return null;
+        }
+
+        // HTTP 요청 파라미터 가져오기
+        String paramName = annotation.value();
+        String rawValue = webRequest.getParameter(paramName);
+
+        // 값이 없으면 빈 리스트 반환
+        if (rawValue == null || rawValue.isEmpty()) {
+            return List.of();
+        }
+
+        // 지정된 delimiter로 문자열을 분할하여 리스트로 변환
+        return Arrays.asList(rawValue.split(annotation.delimiter()));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/common/resolver/SplitRequestParamResolver.java
+++ b/Trim-Api/src/main/java/trim/api/common/resolver/SplitRequestParamResolver.java
@@ -36,8 +36,8 @@ public class SplitRequestParamResolver implements HandlerMethodArgumentResolver 
         String rawValue = webRequest.getParameter(paramName);
 
         // 값이 없으면 빈 리스트 반환
-        if (rawValue == null || rawValue.isEmpty()) {
-            return List.of();
+        if (rawValue == null) {
+            return annotation.nullable() ? null : List.of();
         }
 
         // 지정된 delimiter로 문자열을 분할하여 리스트로 변환

--- a/Trim-Api/src/main/java/trim/api/config/WebMvcConfig.java
+++ b/Trim-Api/src/main/java/trim/api/config/WebMvcConfig.java
@@ -1,14 +1,26 @@
 package trim.api.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import trim.common.util.StaticValues;
+import trim.api.common.resolver.SplitRequestParamResolver;
+
+import java.util.List;
 
 import static trim.common.util.StaticValues.CORS_FRONT_LOCAL_PATH;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final SplitRequestParamResolver splitRequestParamResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(splitRequestParamResolver);
+    }
 
     //CORS setting
     @Override

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -2,6 +2,7 @@ package trim.api.domains.knowledge.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
 import trim.api.domains.knowledge.vo.response.KnowledgeListResponse;
 import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
+import trim.common.annotation.RequestParamList;
 
 import java.util.List;
 
@@ -71,7 +73,7 @@ public class KnowledgeApiController {
             "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
     @GetMapping("/search")
     public ApiResponseDto<KnowledgeListResponse> searchKnowledge(@RequestParam(required = false) String majorType,
-                                                                 @RequestParam(required = false) List<String> keyword,
+                                                                 @Nullable @RequestParamList(value = "keyword") List<String> keyword,
                                                                  @RequestParam(defaultValue = "0") int currentPage,
                                                                  @RequestParam int pageSize) {
 

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -3,6 +3,7 @@ package trim.api.domains.question.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
@@ -13,11 +14,13 @@ import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.api.domains.question.vo.response.QuestionDetailResponse;
 import trim.api.domains.question.vo.response.QuestionListResponse;
 import trim.api.domains.question.vo.response.QuestionSummaryResponse;
+import trim.common.annotation.RequestParamList;
 
 import java.util.List;
 
 import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
 
+@Slf4j
 @Tag(name = "[질문 게시판]")
 @RequiredArgsConstructor
 @RestController
@@ -81,9 +84,10 @@ public class QuestionApiController {
             "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
     @GetMapping("/search")
     public ApiResponseDto<QuestionListResponse> searchQuestions(@RequestParam(required = false) String majorType,
-                                                                @RequestParam(required = false) List<String> keyword,
+                                                                @RequestParamList("keyword") List<String> keyword,
                                                                 @RequestParam(defaultValue = "0") int currentPage,
                                                                 @RequestParam int pageSize) {
+        keyword.forEach(key -> log.info("keyword = {}", key));
         Pageable pageable = PageRequest.of(currentPage, pageSize);
         return ApiResponseDto.onSuccess(searchQuestionsUseCase.execute(majorType, keyword, pageable));
     }

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -2,6 +2,7 @@ package trim.api.domains.question.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -84,10 +85,9 @@ public class QuestionApiController {
             "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
     @GetMapping("/search")
     public ApiResponseDto<QuestionListResponse> searchQuestions(@RequestParam(required = false) String majorType,
-                                                                @RequestParamList("keyword") List<String> keyword,
+                                                                @Nullable @RequestParamList(value = "keyword") List<String> keyword,
                                                                 @RequestParam(defaultValue = "0") int currentPage,
                                                                 @RequestParam int pageSize) {
-        keyword.forEach(key -> log.info("keyword = {}", key));
         Pageable pageable = PageRequest.of(currentPage, pageSize);
         return ApiResponseDto.onSuccess(searchQuestionsUseCase.execute(majorType, keyword, pageable));
     }

--- a/Trim-Common/src/main/java/trim/common/annotation/RequestParamList.java
+++ b/Trim-Common/src/main/java/trim/common/annotation/RequestParamList.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RequestParamList {
     String value(); // 원래 `@RequestParam`에서 쓰이는 값
-    String delimiter() default "\\+"; // 기본 구분자 `+`
+    String delimiter() default ","; // 기본 구분자 `+`
 }

--- a/Trim-Common/src/main/java/trim/common/annotation/RequestParamList.java
+++ b/Trim-Common/src/main/java/trim/common/annotation/RequestParamList.java
@@ -1,0 +1,13 @@
+package trim.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestParamList {
+    String value(); // 원래 `@RequestParam`에서 쓰이는 값
+    String delimiter() default "\\+"; // 기본 구분자 `+`
+}

--- a/Trim-Common/src/main/java/trim/common/annotation/RequestParamList.java
+++ b/Trim-Common/src/main/java/trim/common/annotation/RequestParamList.java
@@ -10,4 +10,5 @@ import java.lang.annotation.Target;
 public @interface RequestParamList {
     String value(); // 원래 `@RequestParam`에서 쓰이는 값
     String delimiter() default ","; // 기본 구분자 `+`
+    boolean nullable() default true;
 }

--- a/Trim-Domain/src/main/java/trim/domains/board/dao/domain/MajorType.java
+++ b/Trim-Domain/src/main/java/trim/domains/board/dao/domain/MajorType.java
@@ -9,41 +9,15 @@ import java.util.Random;
 @Getter
 @RequiredArgsConstructor
 public enum MajorType implements KeyedEnum {
-    // Humanities & Social Sciences
-    LIBERAL_ARTS("Liberal Arts College"),
-    SOCIAL_SCIENCES("Social Sciences College"),
-    BUSINESS_ADMINISTRATION("Business Administration College"),
-    LAW("Law College"),
-    EDUCATION("Education College"),
+    ENGINEERING("engineering"),
+    EDUCATION("education"),
+    SOCIAL_SCIENCES("social-sciences"),
+    ARTS_PHYSICAL_EDUCATION("arts-physical-education"),
+    MEDICINE_PHARMACY("medicine-pharmacy"),
+    HUMANITIES("humanities"),
+    NATURAL_SCIENCES("natural-sciences"),
+    ETC("etc");
 
-    // Natural Sciences
-    NATURAL_SCIENCES("Natural Sciences College"),
-    LIFE_SCIENCES("Life Sciences College"),
-    VETERINARY_MEDICINE("Veterinary Medicine College"),
-    PHARMACY("Pharmacy College"),
-
-    // Engineering
-    ENGINEERING("Engineering College"),
-    INFORMATION_COMMUNICATIONS("Information & Communications College"),
-    INDUSTRIAL_ENGINEERING("Industrial Engineering College"),
-
-    // Arts & Sports
-    MUSIC("Music College"),
-    FINE_ARTS("Fine Arts College"),
-    PHYSICAL_EDUCATION("Physical Education College"),
-
-    // Medical
-    MEDICINE("Medical College"),
-    DENTISTRY("Dentistry College"),
-    NURSING("Nursing College"),
-
-    // Agriculture & Marine
-    AGRICULTURAL_LIFE_SCIENCES("Agricultural & Life Sciences College"),
-    MARINE_SCIENCES("Marine Sciences College"),
-
-    // Human Ecology
-    HUMAN_ECOLOGY("Human Ecology College"),
-    HOUSING_ENVIRONMENT("Housing Environment College");
 
     private final String key;
 


### PR DESCRIPTION
## #️⃣ 요약 설명
>프론트 요청사항 수정
## 📝 작업 내용

- https://github.com/trim-project/trim-back-mm/issues/45
- majortype 변경
- annotation을 사용하여서 requestParam 요청 방식을 keyword=A&keyword=B와 같은 형식에서 keyword=A,B,C로 변경

## 동작 확인

<img width="814" alt="스크린샷 2025-03-11 오후 2 18 27" src="https://github.com/user-attachments/assets/86c80590-3a74-4163-ba47-a3db683b737a" />
<img width="553" alt="스크린샷 2025-03-11 오후 2 18 55" src="https://github.com/user-attachments/assets/741cd559-ae2e-454d-ab0f-6334317f0a5b" />
