### PR TITLE
[Refactor/#48] divide api to access or auth

### DIFF
--- a/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/common/init/DataInitializeApiController.java
@@ -14,7 +14,7 @@ import trim.api.domains.member.service.CreateQuestionDummyDataUseCase;
 @Tag(name = "[더미 데이터 입력]")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/dummy")
+@RequestMapping("/api/access/dummy")
 public class DataInitializeApiController {
 
     private final CreateMemberDummyDataUseCase createMemberDummyDataUseCase;

--- a/Trim-Api/src/main/java/trim/api/common/resolver/CustomAuthenticationPrincipalArgumentResolver.java
+++ b/Trim-Api/src/main/java/trim/api/common/resolver/CustomAuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,56 @@
+package trim.api.common.resolver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
+
+import static trim.common.util.AnnotationUtil.findMethodAnnotation;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public final class CustomAuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberAdaptor memberAdaptor;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return findMethodAnnotation(AuthUser.class, parameter) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Object principal = authentication.getPrincipal();
+        AuthUser annotation = findMethodAnnotation(AuthUser.class, parameter);
+        if (principal == "anonymousUser") {
+            throw new RuntimeException();
+        }
+        findMethodAnnotation(AuthUser.class, parameter);
+        Member member = memberAdaptor.queryMemberByUsername(authentication.getName());
+
+        if (principal != null && !ClassUtils.isAssignable(parameter.getParameterType(), member.getClass())) {
+            if (annotation.errorOnInvalidType()) {
+                throw new RuntimeException();
+            }
+        }
+
+        return member;
+    }
+
+
+}

--- a/Trim-Api/src/main/java/trim/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/Trim-Api/src/main/java/trim/api/common/security/filter/JwtAuthenticationFilter.java
@@ -15,6 +15,9 @@ import trim.api.common.security.service.TokenService;
 
 import java.io.IOException;
 
+import static trim.common.util.StaticValues.AUTHORIZATION;
+import static trim.common.util.StaticValues.BEARER;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -49,9 +52,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
+        String bearerToken = request.getHeader(AUTHORIZATION);
 
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
             return bearerToken.substring(7);
         }
         return null;

--- a/Trim-Api/src/main/java/trim/api/config/SwaggerConfig.java
+++ b/Trim-Api/src/main/java/trim/api/config/SwaggerConfig.java
@@ -11,29 +11,33 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.servlet.ServletContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.OperationCustomizer;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.HandlerMethod;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.common.dto.ExampleHolder;
-import trim.common.annotation.ApiErrorStatusExample;
 import trim.common.annotation.ApiErrorExceptionsExample;
+import trim.common.annotation.ApiErrorStatusExample;
 import trim.common.annotation.DisableSwaggerSecurity;
 import trim.common.annotation.ExplainError;
-import trim.common.exception.*;
+import trim.common.exception.BaseErrorCode;
+import trim.common.exception.GeneralException;
+import trim.common.exception.Reason;
 
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
+import static trim.common.util.StaticValues.*;
 
 /** Swagger 사용 환경을 위한 설정 파일 */
 @Slf4j
@@ -47,7 +51,11 @@ public class SwaggerConfig {
     public OpenAPI openAPI(ServletContext servletContext) {
         String contextPath = servletContext.getContextPath();
         Server server = new Server().url(contextPath);
-        return new OpenAPI().servers(List.of(server)).components(authSetting()).info(swaggerInfo());
+        return new OpenAPI()
+                .servers(List.of(server))
+                .components(authSetting())
+                .addSecurityItem(new SecurityRequirement().addList(JWT))
+                .info(swaggerInfo());
     }
 
     private Info swaggerInfo() {
@@ -65,13 +73,13 @@ public class SwaggerConfig {
     private Components authSetting() {
         return new Components()
                 .addSecuritySchemes(
-                        "access-token",
+                        JWT,
                         new SecurityScheme()
                                 .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
+                                .scheme(BEARER)
+                                .bearerFormat(AUTHORIZATION)
                                 .in(SecurityScheme.In.HEADER)
-                                .name("Authorization"));
+                                .name(JWT));
     }
 
 

--- a/Trim-Api/src/main/java/trim/api/config/WebMvcConfig.java
+++ b/Trim-Api/src/main/java/trim/api/config/WebMvcConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import trim.api.common.resolver.CustomAuthenticationPrincipalArgumentResolver;
 import trim.api.common.resolver.SplitRequestParamResolver;
 
 import java.util.List;
@@ -16,10 +17,12 @@ import static trim.common.util.StaticValues.CORS_FRONT_LOCAL_PATH;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final SplitRequestParamResolver splitRequestParamResolver;
+    private final CustomAuthenticationPrincipalArgumentResolver customAuthenticationPrincipalArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(splitRequestParamResolver);
+        resolvers.add(customAuthenticationPrincipalArgumentResolver);
     }
 
     //CORS setting

--- a/Trim-Api/src/main/java/trim/api/domains/answer/controller/AnswerApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/controller/AnswerApiController.java
@@ -8,7 +8,7 @@ import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.answer.service.WriteAnswerUseCase;
 import trim.api.domains.answer.vo.AnswerRequest;
 
-@Tag(name = "[답글 게시판]")
+@Tag(name = "[답글 게시판🔑]")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/answers")

--- a/Trim-Api/src/main/java/trim/api/domains/answer/controller/AnswerApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/controller/AnswerApiController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.answer.service.WriteAnswerUseCase;
 import trim.api.domains.answer.vo.AnswerRequest;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.dao.domain.Member;
 
 @Tag(name = "[답글 게시판🔑]")
 @RestController
@@ -17,10 +19,10 @@ public class AnswerApiController {
     private final WriteAnswerUseCase writeAnswerUseCase;
 
     @Operation(summary = "질문 게시글의 답글 게시글을 작성합니다.")
-    @PostMapping("/questions/{questionId}/members/{memberId}")
-    public ApiResponseDto<Long> writeAnswer(@PathVariable Long questionId,
-                                            @PathVariable Long memberId,
+    @PostMapping("/questions/{questionId}")
+    public ApiResponseDto<Long> writeAnswer(@AuthUser Member member,
+                                            @PathVariable Long questionId,
                                             @RequestBody AnswerRequest request) {
-        return ApiResponseDto.onSuccess(writeAnswerUseCase.execute(questionId, memberId, request));
+        return ApiResponseDto.onSuccess(writeAnswerUseCase.execute(questionId, member, request));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/answer/service/CreateAnswerDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/service/CreateAnswerDummyDataUseCase.java
@@ -3,27 +3,26 @@ package trim.api.domains.answer.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import trim.api.domains.answer.vo.AnswerRequest;
-import trim.api.domains.knowledge.service.WriteKnowledgeUseCase;
-import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.common.annotation.UseCase;
-import trim.domains.board.dao.domain.MajorType;
-
-import java.util.List;
+import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
 
 @UseCase
 @Transactional
 @RequiredArgsConstructor
 public class CreateAnswerDummyDataUseCase {
 
+    private final MemberAdaptor memberAdaptor;
     private final WriteAnswerUseCase writeAnswerUseCase;
 
     public Boolean execute(Long questionId, Long memberId, int knowledgeCount) {
+        Member member = memberAdaptor.queryMember(memberId);
         for (int i = 0; i < knowledgeCount; i++) {
             AnswerRequest request = AnswerRequest.builder()
                     .title("title of answer" + i + "by" + memberId)
                     .content("content of answer" + i + "by" + memberId)
                     .build();
-            writeAnswerUseCase.execute(questionId, memberId, request);
+            writeAnswerUseCase.execute(questionId, member, request);
         }
         return true;
     }

--- a/Trim-Api/src/main/java/trim/api/domains/answer/service/WriteAnswerUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/answer/service/WriteAnswerUseCase.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import trim.api.domains.answer.vo.AnswerRequest;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.service.AnswerDomainService;
-import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
 
 @UseCase
@@ -12,10 +11,8 @@ import trim.domains.member.dao.domain.Member;
 public class WriteAnswerUseCase {
 
     private final AnswerDomainService answerDomainService;
-    private final MemberAdaptor memberAdaptor;
 
-    public Long execute(Long questionId, Long memberId, AnswerRequest request) {
-        Member member = memberAdaptor.queryMember(memberId);
+    public Long execute(Long questionId, Member member, AnswerRequest request) {
         return answerDomainService.writeAnswer(request.from(), member, questionId).getId();
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/badge/controller/BadgeAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/badge/controller/BadgeAccessApiController.java
@@ -1,0 +1,28 @@
+package trim.api.domains.badge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.badge.service.GetAllBadgesUseCase;
+import trim.api.domains.badge.vo.response.BadgeResponse;
+
+import java.util.List;
+
+@Tag(name = "[뱃지]")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/access/badges")
+public class BadgeAccessApiController {
+
+    private final GetAllBadgesUseCase getAllBadgesUseCase;
+
+    @Operation(summary = "모든 뱃지를 조회합니다.")
+    @GetMapping
+    public ApiResponseDto<List<BadgeResponse>> getAllBadges() {
+        return ApiResponseDto.onSuccess(getAllBadgesUseCase.execute());
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/badge/controller/BadgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/badge/controller/BadgeApiController.java
@@ -7,31 +7,23 @@ import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.badge.service.CountUpBadgeOfWritingBoardUseCase;
 import trim.api.domains.badge.service.GetAllBadgesByMemberUseCase;
-import trim.api.domains.badge.service.GetAllBadgesUseCase;
 import trim.api.domains.badge.service.UpgradeBadgeLevelUseCase;
 import trim.api.domains.badge.vo.response.BadgeDetailResponse;
-import trim.api.domains.badge.vo.response.BadgeResponse;
 import trim.common.util.EnumConvertUtil;
 import trim.domains.badge.dao.entity.BadgeContent;
 
 import java.util.List;
 
-@Tag(name = "[뱃지]")
+@Tag(name = "[뱃지🔑]")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/badges")
 public class BadgeApiController {
 
-    private final GetAllBadgesUseCase getAllBadgesUseCase;
     private final UpgradeBadgeLevelUseCase upgradeBadgeLevelUseCase;
     private final CountUpBadgeOfWritingBoardUseCase countUpBadgeOfWritingBoardUseCase;
     private final GetAllBadgesByMemberUseCase getAllBadgesByMemberUseCase;
 
-    @Operation(summary = "모든 뱃지를 조회합니다.")
-    @GetMapping
-    public ApiResponseDto<List<BadgeResponse>> getAllBadges() {
-        return ApiResponseDto.onSuccess(getAllBadgesUseCase.execute());
-    }
 
     @Operation(summary = "모든 뱃지를 조회합니다. 이때 사용자의 미션 상태를 반영하여 값을 가져옵니다.")
     @GetMapping("/members/{memberId}")
@@ -54,6 +46,5 @@ public class BadgeApiController {
         return ApiResponseDto.onSuccess(countUpBadgeOfWritingBoardUseCase
                 .execute(badgeContent, memberId));
     }
-
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/badge/controller/BadgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/badge/controller/BadgeApiController.java
@@ -9,8 +9,10 @@ import trim.api.domains.badge.service.CountUpBadgeOfWritingBoardUseCase;
 import trim.api.domains.badge.service.GetAllBadgesByMemberUseCase;
 import trim.api.domains.badge.service.UpgradeBadgeLevelUseCase;
 import trim.api.domains.badge.vo.response.BadgeDetailResponse;
+import trim.common.annotation.AuthUser;
 import trim.common.util.EnumConvertUtil;
 import trim.domains.badge.dao.entity.BadgeContent;
+import trim.domains.member.dao.domain.Member;
 
 import java.util.List;
 
@@ -26,25 +28,25 @@ public class BadgeApiController {
 
 
     @Operation(summary = "모든 뱃지를 조회합니다. 이때 사용자의 미션 상태를 반영하여 값을 가져옵니다.")
-    @GetMapping("/members/{memberId}")
+    @GetMapping
     public ApiResponseDto<List<BadgeDetailResponse>> getAllBadgesByMember(@PathVariable Long memberId) {
         return ApiResponseDto.onSuccess(getAllBadgesByMemberUseCase.execute(memberId));
     }
 
     @Operation(summary = "미션의 단계를 업그레이드 합니다. 현재 완성한 배지를 획득합니다.")
-    @PostMapping("/{badgeId}/members/{memberId}")
-    public ApiResponseDto<Integer> upgradeBadgeLevel(@PathVariable Long badgeId,
-                                                     @PathVariable Long memberId) {
-        return ApiResponseDto.onSuccess(upgradeBadgeLevelUseCase.execute(badgeId, memberId));
+    @PostMapping("/{badgeId}")
+    public ApiResponseDto<Integer> upgradeBadgeLevel(@AuthUser Member member,
+                                                     @PathVariable Long badgeId) {
+        return ApiResponseDto.onSuccess(upgradeBadgeLevelUseCase.execute(badgeId, member));
     }
 
     @Operation(summary = "게시글 작성을 함으로써 미션의 카운트를 하나 올려줍니다.")
-    @PutMapping("/boards/members/{memberId}")
-    public ApiResponseDto<Long> countUpBadgeOfWritingBoard(@PathVariable Long memberId,
+    @PatchMapping("/boards")
+    public ApiResponseDto<Long> countUpBadgeOfWritingBoard(@AuthUser Member member,
                                                            @RequestParam String badgeContentKey) {
         BadgeContent badgeContent = EnumConvertUtil.convert(BadgeContent.class, badgeContentKey);
         return ApiResponseDto.onSuccess(countUpBadgeOfWritingBoardUseCase
-                .execute(badgeContent, memberId));
+                .execute(badgeContent, member));
     }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/badge/service/CountUpBadgeOfWritingBoardUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/badge/service/CountUpBadgeOfWritingBoardUseCase.java
@@ -6,13 +6,9 @@ import trim.common.annotation.UseCase;
 import trim.common.exception.ErrorStatus;
 import trim.common.exception.GeneralException;
 import trim.domains.badge.dao.entity.BadgeContent;
-import trim.domains.board.dao.domain.BoardType;
-import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
 import trim.domains.mission.business.adaptor.MissionAdaptor;
-import trim.domains.mission.business.service.MissionDomainService;
 import trim.domains.mission.dao.entity.Mission;
-import trim.domains.mission.dao.entity.MissionStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,12 +21,8 @@ import static trim.domains.mission.dao.entity.MissionStatus.IN_PROGRESS;
 public class CountUpBadgeOfWritingBoardUseCase {
 
     private final MissionAdaptor missionAdaptor;
-    private final MissionDomainService missionDomainService;
-    private final MemberAdaptor memberAdaptor;
 
-
-    public Long execute(BadgeContent badgeContent, Long memberId) {
-        Member member = memberAdaptor.queryMember(memberId);
+    public Long execute(BadgeContent badgeContent, Member member) {
         List<Mission> missions = missionAdaptor.queryMissionByBadgeContentAndMember(badgeContent, member);
         Optional<Mission> inProgressMission = missions.stream()
                 .filter(mission -> mission.getMissionStatus().equals(IN_PROGRESS))

--- a/Trim-Api/src/main/java/trim/api/domains/badge/service/UpgradeBadgeLevelUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/badge/service/UpgradeBadgeLevelUseCase.java
@@ -5,7 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 import trim.common.annotation.UseCase;
 import trim.domains.badge.business.adaptor.BadgeAdaptor;
 import trim.domains.badge.dao.entity.Badge;
-import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
 import trim.domains.mission.business.adaptor.MissionAdaptor;
 import trim.domains.mission.business.service.MissionDomainService;
@@ -23,15 +22,15 @@ public class UpgradeBadgeLevelUseCase {
     private final MissionValidator missionValidator;
     private final MissionDomainService missionDomainService;
 
-    public Integer execute(Long badgeId, Long memberId) {
+    public Integer execute(Long badgeId, Member member) {
         Mission completedMission
-                = missionAdaptor.queryMissionByBadgeIdAndMemberId(badgeId, memberId);
+                = missionAdaptor.queryMissionByBadgeIdAndMemberId(badgeId, member.getId());
         int nextLevel = completedMission.getBadge().getLevel() + 1;
         // VALIDATE MISSION IS COMPLETED
         if(!missionValidator.isCompletedMission(completedMission)) throw MissionHandler.NOT_CLEARED;
         // GET NEXT BADGE
         Badge nextBadge = badgeAdaptor.queryByContentAndLevel(completedMission.getBadge().getBadgeContent(), nextLevel);
-        Mission mission = missionAdaptor.queryMissionByBadgeIdAndMemberId(nextBadge.getId(), memberId);
+        Mission mission = missionAdaptor.queryMissionByBadgeIdAndMemberId(nextBadge.getId(), member.getId());
         mission.unlocked();
         return nextLevel;
     }

--- a/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentAccessApiController.java
@@ -1,0 +1,37 @@
+package trim.api.domains.comment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.comment.service.GetCommentCountUseCase;
+import trim.api.domains.comment.service.GetCommentsOfBoardUseCase;
+import trim.api.domains.comment.vo.response.CommentDetailResponse;
+
+import java.util.List;
+
+@Tag(name = "[댓글]")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/access/comments")
+public class CommentAccessApiController {
+
+    private final GetCommentsOfBoardUseCase getCommentsOfBoardUseCase;
+    private final GetCommentCountUseCase getCommentCountUseCase;
+
+    @Operation(summary = "게시글의 모든 댓글을 조회합니다. 이때 게시글은 PK로 조회합니다.")
+    @GetMapping("/{boardId}")
+    public ApiResponseDto<List<CommentDetailResponse>> getCommentsOfBoard(@PathVariable Long boardId) {
+        return ApiResponseDto.onSuccess(getCommentsOfBoardUseCase.execute(boardId));
+    }
+
+    @Operation(summary = "게시글의 댓글 개수를 조회합니다. 주로 상세페이지에서 사용될 예정입니다.")
+    @GetMapping("/boards/{boardId}")
+    public ApiResponseDto<Long> getCommentCount(@PathVariable Long boardId) {
+        return ApiResponseDto.onSuccess(getCommentCountUseCase.execute(boardId));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
@@ -5,29 +5,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.domains.comment.service.GetCommentCountUseCase;
 import trim.api.domains.comment.service.WriteCommentUseCase;
-import trim.api.domains.comment.service.GetCommentsOfBoardUseCase;
 import trim.api.domains.comment.vo.request.CommentRequest;
-import trim.api.domains.comment.vo.response.CommentDetailResponse;
 
-import java.util.List;
-
-@Tag(name = "[댓글]")
+@Tag(name = "[댓글🔑]")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/comments")
 public class CommentApiController {
 
-    private final GetCommentsOfBoardUseCase getCommentsOfBoardUseCase;
     private final WriteCommentUseCase writeCommentUseCase;
-    private final GetCommentCountUseCase getCommentCountUseCase;
-
-    @Operation(summary = "게시글의 모든 댓글을 조회합니다. 이때 게시글은 PK로 조회합니다.")
-    @GetMapping("/{boardId}")
-    public ApiResponseDto<List<CommentDetailResponse>> getCommentsOfBoard(@PathVariable Long boardId) {
-        return ApiResponseDto.onSuccess(getCommentsOfBoardUseCase.execute(boardId));
-    }
 
     @Operation(summary = "게시글의 댓글을 작성합니다. 이때 게시글의 타입은 신경쓰지 않습니다.")
     @PostMapping("/boards/{boardId}/members/{memberId}")
@@ -37,9 +24,5 @@ public class CommentApiController {
         return ApiResponseDto.onSuccess(writeCommentUseCase.execute(memberId, boardId, request.getContent()));
     }
 
-    @Operation(summary = "게시글의 댓글 개수를 조회합니다. 주로 상세페이지에서 사용될 예정입니다.")
-    @GetMapping("/boards/{boardId}")
-    public ApiResponseDto<Long> getCommentCount(@PathVariable Long boardId) {
-        return ApiResponseDto.onSuccess(getCommentCountUseCase.execute(boardId));
-    }
+
 }

--- a/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/controller/CommentApiController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.comment.service.WriteCommentUseCase;
 import trim.api.domains.comment.vo.request.CommentRequest;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.dao.domain.Member;
 
 @Tag(name = "[댓글🔑]")
 @RestController
@@ -17,11 +19,11 @@ public class CommentApiController {
     private final WriteCommentUseCase writeCommentUseCase;
 
     @Operation(summary = "게시글의 댓글을 작성합니다. 이때 게시글의 타입은 신경쓰지 않습니다.")
-    @PostMapping("/boards/{boardId}/members/{memberId}")
-    public ApiResponseDto<Long> writeComment(@PathVariable Long boardId,
-                                             @PathVariable Long memberId,
+    @PostMapping("/boards/{boardId}")
+    public ApiResponseDto<Long> writeComment(@AuthUser Member member,
+                                             @PathVariable Long boardId,
                                              @RequestBody CommentRequest request) {
-        return ApiResponseDto.onSuccess(writeCommentUseCase.execute(memberId, boardId, request.getContent()));
+        return ApiResponseDto.onSuccess(writeCommentUseCase.execute(member, boardId, request.getContent()));
     }
 
 

--- a/Trim-Api/src/main/java/trim/api/domains/comment/service/WriteCommentUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/comment/service/WriteCommentUseCase.java
@@ -2,9 +2,9 @@ package trim.api.domains.comment.service;
 
 import lombok.RequiredArgsConstructor;
 import trim.common.annotation.UseCase;
-import trim.domains.board.business.adaptor.QuestionAdaptor;
 import trim.domains.comment.business.service.CommentDomainService;
 import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
 
 
 @UseCase
@@ -14,9 +14,9 @@ public class WriteCommentUseCase {
     private final CommentDomainService commentDomainService;
     private final MemberAdaptor memberAdaptor;
 
-    public Long execute(Long memberId, Long questionId, String content){
+    public Long execute(Member member, Long questionId, String content){
         return commentDomainService.createComment(
-                memberAdaptor.queryMember(memberId),
+                member,
                 questionId,
                 content
         ).getId();

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkAccessApiController.java
@@ -1,0 +1,61 @@
+package trim.api.domains.freetalk.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.common.util.PageUtil;
+import trim.api.domains.freetalk.service.GetAllFreeTalkByPaginationUseCase;
+import trim.api.domains.freetalk.service.GetAllFreeTalkUseCase;
+import trim.api.domains.freetalk.service.GetHotFreeTalksUseCase;
+import trim.api.domains.freetalk.service.GetSpecificFreeTalkUseCase;
+import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
+import trim.api.domains.freetalk.vo.response.FreeTalkListResponse;
+import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
+
+import java.util.List;
+
+import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
+
+@Tag(name = "[자유 게시판]")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/access/free-talks")
+public class FreeTalkAccessApiController {
+
+    private final GetAllFreeTalkUseCase getAllFreeTalkUseCase;
+    private final GetSpecificFreeTalkUseCase getSpecificFreeTalkUseCase;
+    private final GetAllFreeTalkByPaginationUseCase getAllFreeTalkByPaginationUseCase;
+    private final GetHotFreeTalksUseCase getHotFreeTalksUseCase;
+
+    @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 조회 형식은 요약본입니다.")
+    @GetMapping
+    public ApiResponseDto<List<FreeTalkSummaryResponse>> getAllFreeTalk() {
+        return ApiResponseDto.onSuccess(getAllFreeTalkUseCase.execute());
+    }
+
+    @Operation(summary = "특정 자유 게시판을 조회합니다.")
+    @GetMapping("/{freeTalkId}")
+    public ApiResponseDto<FreeTalkDetailResponse> getSpecificFreeTalk(@PathVariable Long freeTalkId) {
+        return ApiResponseDto.onSuccess(getSpecificFreeTalkUseCase.execute(freeTalkId));
+    }
+
+    @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
+    @GetMapping("/page")
+    public ApiResponseDto<FreeTalkListResponse> getAllFreeTalkByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);
+        return ApiResponseDto.onSuccess(getAllFreeTalkByPaginationUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "자유 게시판의 인기 게시글 6개를 조회합니다.")
+    @GetMapping("/hot-issue")
+    public ApiResponseDto<List<FreeTalkSummaryResponse>> getHotFreeTalks() {
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
+        return ApiResponseDto.onSuccess(getHotFreeTalksUseCase.execute(pageable));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -3,33 +3,18 @@ package trim.api.domains.freetalk.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.common.util.PageUtil;
 import trim.api.domains.freetalk.service.*;
-import trim.api.domains.freetalk.vo.response.FreeTalkDetailResponse;
 import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
-import trim.api.domains.freetalk.vo.response.FreeTalkListResponse;
-import trim.api.domains.freetalk.vo.response.FreeTalkSummaryResponse;
-import trim.api.domains.question.vo.response.QuestionSummaryResponse;
 
-import java.util.List;
-
-import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
-
-@Tag(name = "[자유 게시판]")
+@Tag(name = "[자유 게시판🔑]")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/free-talks")
 public class FreeTalkApiController {
 
     private final WriteFreeTalkUseCase writeFreeTalkUseCase;
-    private final GetAllFreeTalkUseCase getAllFreeTalkUseCase;
-    private final GetSpecificFreeTalkUseCase getSpecificFreeTalkUseCase;
-    private final GetAllFreeTalkByPaginationUseCase getAllFreeTalkByPaginationUseCase;
-    private final GetHotFreeTalksUseCase getHotFreeTalksUseCase;
 
     @Operation(summary = "자유 게시판 글을 작성합니다.")
     @PostMapping("/members/{memberId}")
@@ -38,31 +23,5 @@ public class FreeTalkApiController {
         return ApiResponseDto.onSuccess(writeFreeTalkUseCase.execute(memberId, request));
     }
 
-    @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 조회 형식은 요약본입니다.")
-    @GetMapping
-    public ApiResponseDto<List<FreeTalkSummaryResponse>> getAllFreeTalk() {
-        return ApiResponseDto.onSuccess(getAllFreeTalkUseCase.execute());
-    }
 
-    @Operation(summary = "특정 자유 게시판을 조회합니다.")
-    @GetMapping("/{freeTalkId}")
-    public ApiResponseDto<FreeTalkDetailResponse> getSpecificFreeTalk(@PathVariable Long freeTalkId) {
-        return ApiResponseDto.onSuccess(getSpecificFreeTalkUseCase.execute(freeTalkId));
-    }
-
-    @Operation(summary = "자유 게시판 글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
-    @GetMapping("/page")
-    public ApiResponseDto<FreeTalkListResponse> getAllFreeTalkByPagination(
-            @RequestParam(defaultValue = "0") int currentPage,
-            @RequestParam int pageSize) {
-        Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);
-        return ApiResponseDto.onSuccess(getAllFreeTalkByPaginationUseCase.execute(pageable));
-    }
-
-    @Operation(summary = "자유 게시판의 인기 게시글 6개를 조회합니다.")
-    @GetMapping("/hot-issue")
-    public ApiResponseDto<List<FreeTalkSummaryResponse>> getHotFreeTalks() {
-        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
-        return ApiResponseDto.onSuccess(getHotFreeTalksUseCase.execute(pageable));
-    }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/controller/FreeTalkApiController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.freetalk.service.*;
 import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.dao.domain.Member;
 
 @Tag(name = "[자유 게시판🔑]")
 @RequiredArgsConstructor
@@ -17,10 +19,10 @@ public class FreeTalkApiController {
     private final WriteFreeTalkUseCase writeFreeTalkUseCase;
 
     @Operation(summary = "자유 게시판 글을 작성합니다.")
-    @PostMapping("/members/{memberId}")
-    public ApiResponseDto<Long> writeFreeTalk(@PathVariable Long memberId,
+    @PostMapping
+    public ApiResponseDto<Long> writeFreeTalk(@AuthUser Member member,
                                               @RequestBody FreeTalkRequest request) {
-        return ApiResponseDto.onSuccess(writeFreeTalkUseCase.execute(memberId, request));
+        return ApiResponseDto.onSuccess(writeFreeTalkUseCase.execute(member, request));
     }
 
 

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/CreateFreeTalkDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/CreateFreeTalkDummyDataUseCase.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
 import trim.common.annotation.UseCase;
+import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
 
 @UseCase
 @Transactional
@@ -11,14 +13,16 @@ import trim.common.annotation.UseCase;
 public class CreateFreeTalkDummyDataUseCase {
 
     private final WriteFreeTalkUseCase writeFreeTalkUseCase;
+    private final MemberAdaptor memberAdaptor;
 
     public Boolean execute(Long memberId, int freeTalkCount) {
+        Member member = memberAdaptor.queryMember(memberId);
         for (int i = 0; i < freeTalkCount; i++) {
             FreeTalkRequest request = FreeTalkRequest.builder()
                     .title("title of FreeTalk" + i + "by" + memberId)
                     .content("content of FreeTalk" + i + "by" + memberId)
                     .build();
-            writeFreeTalkUseCase.execute(memberId, request);
+            writeFreeTalkUseCase.execute(member, request);
         }
         return true;
     }

--- a/Trim-Api/src/main/java/trim/api/domains/freetalk/service/WriteFreeTalkUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/freetalk/service/WriteFreeTalkUseCase.java
@@ -16,8 +16,7 @@ public class WriteFreeTalkUseCase {
     private final FreeTalkDomainService freeTalkDomainService;
     private final MemberAdaptor memberAdaptor;
 
-    public Long execute(Long memberId, FreeTalkRequest request) {
-        Member member = memberAdaptor.queryMember(memberId);
+    public Long execute(Member member, FreeTalkRequest request) {
         return freeTalkDomainService.createFreeTalk(member, request.from()).getId();
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeAccessApiController.java
@@ -1,0 +1,74 @@
+package trim.api.domains.knowledge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.common.util.PageUtil;
+import trim.api.domains.knowledge.service.*;
+import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
+import trim.api.domains.knowledge.vo.response.KnowledgeListResponse;
+import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
+import trim.common.annotation.RequestParamList;
+
+import java.util.List;
+
+import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
+
+@Tag(name = "[지식 공유]")
+@RestController
+@RequestMapping("/api/access/knowledge")
+@RequiredArgsConstructor
+public class KnowledgeAccessApiController {
+
+    private final GetAllKnowledgeUseCase getAllKnowledgeUseCase;
+    private final GetSpecificKnowledgeUseCase getSpecificKnowledgeUseCase;
+    private final GetAllKnowledgeByPaginationUseCase getAllKnowledgeByPaginationUseCase;
+    private final GetHotKnowledgeUseCase getHotKnowledgeUseCase;
+    private final SearchKnowledgeUseCase searchKnowledgeUseCase;
+
+    @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 형식은 요약입니다.")
+    @GetMapping
+    public ApiResponseDto<List<KnowledgeSummaryResponse>> getAllKnowledge() {
+        return ApiResponseDto.onSuccess(getAllKnowledgeUseCase.execute());
+    }
+
+    @Operation(summary = "특정 지식 공유 게시글을 조회합니다.")
+    @GetMapping("/{knowledgeId}")
+    public ApiResponseDto<KnowledgeDetailResponse> getSpecificKnowledge(@PathVariable Long knowledgeId) {
+        return ApiResponseDto.onSuccess(getSpecificKnowledgeUseCase.execute(knowledgeId));
+    }
+
+    @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
+    @GetMapping("/page")
+    public ApiResponseDto<KnowledgeListResponse> getAllKnowledgeByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize
+    ) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);
+        return ApiResponseDto.onSuccess(getAllKnowledgeByPaginationUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "지식 공유 게시판의 인기 게시글 6개를 조회합니다.")
+    @GetMapping("/hot-issue")
+    public ApiResponseDto<List<KnowledgeSummaryResponse>> getHotKnowledge() {
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
+        return ApiResponseDto.onSuccess(getHotKnowledgeUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "지식공유 게시글을 검색합니다. 이때 사용되는 항목은 학과 계열과 키워드 리스트입니다" +
+            "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
+    @GetMapping("/search")
+    public ApiResponseDto<KnowledgeListResponse> searchKnowledge(@RequestParam(required = false) String majorType,
+                                                                 @Nullable @RequestParamList(value = "keyword") List<String> keyword,
+                                                                 @RequestParam(defaultValue = "0") int currentPage,
+                                                                 @RequestParam int pageSize) {
+
+        Pageable pageable = PageRequest.of(currentPage, pageSize);
+        return ApiResponseDto.onSuccess(searchKnowledgeUseCase.execute(majorType, keyword, pageable));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.knowledge.service.*;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.dao.domain.Member;
 
 @Tag(name = "[지식 공유🔑]")
 @RestController
@@ -17,9 +19,9 @@ public class KnowledgeApiController {
     private final WriteKnowledgeUseCase writeKnowledgeUseCase;
 
     @Operation(summary = "지식 공유 게시글을 작성합니다.")
-    @PostMapping("/members/{memberId}")
-    public ApiResponseDto<Long> writeKnowledge(@PathVariable Long memberId,
+    @PostMapping
+    public ApiResponseDto<Long> writeKnowledge(@AuthUser Member member,
                                                @RequestBody KnowledgeRequest request) {
-        return ApiResponseDto.onSuccess(writeKnowledgeUseCase.execute(memberId, request));
+        return ApiResponseDto.onSuccess(writeKnowledgeUseCase.execute(member, request));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/controller/KnowledgeApiController.java
@@ -2,82 +2,24 @@ package trim.api.domains.knowledge.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.common.util.PageUtil;
 import trim.api.domains.knowledge.service.*;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
-import trim.api.domains.knowledge.vo.response.KnowledgeDetailResponse;
-import trim.api.domains.knowledge.vo.response.KnowledgeListResponse;
-import trim.api.domains.knowledge.vo.response.KnowledgeSummaryResponse;
-import trim.common.annotation.RequestParamList;
 
-import java.util.List;
-
-import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
-
-@Tag(name = "[지식 공유]")
+@Tag(name = "[지식 공유🔑]")
 @RestController
 @RequestMapping("/api/knowledge")
 @RequiredArgsConstructor
 public class KnowledgeApiController {
 
     private final WriteKnowledgeUseCase writeKnowledgeUseCase;
-    private final GetAllKnowledgeUseCase getAllKnowledgeUseCase;
-    private final GetSpecificKnowledgeUseCase getSpecificKnowledgeUseCase;
-    private final GetAllKnowledgeByPaginationUseCase getAllKnowledgeByPaginationUseCase;
-    private final GetHotKnowledgeUseCase getHotKnowledgeUseCase;
-    private final SearchKnowledgeUseCase searchKnowledgeUseCase;
 
     @Operation(summary = "지식 공유 게시글을 작성합니다.")
     @PostMapping("/members/{memberId}")
     public ApiResponseDto<Long> writeKnowledge(@PathVariable Long memberId,
                                                @RequestBody KnowledgeRequest request) {
         return ApiResponseDto.onSuccess(writeKnowledgeUseCase.execute(memberId, request));
-    }
-
-    @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 형식은 요약입니다.")
-    @GetMapping
-    public ApiResponseDto<List<KnowledgeSummaryResponse>> getAllKnowledge() {
-        return ApiResponseDto.onSuccess(getAllKnowledgeUseCase.execute());
-    }
-
-    @Operation(summary = "특정 지식 공유 게시글을 조회합니다.")
-    @GetMapping("/{knowledgeId}")
-    public ApiResponseDto<KnowledgeDetailResponse> getSpecificKnowledge(@PathVariable Long knowledgeId) {
-        return ApiResponseDto.onSuccess(getSpecificKnowledgeUseCase.execute(knowledgeId));
-    }
-
-    @Operation(summary = "지식 공유 게시글을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
-    @GetMapping("/page")
-    public ApiResponseDto<KnowledgeListResponse> getAllKnowledgeByPagination(
-            @RequestParam(defaultValue = "0") int currentPage,
-            @RequestParam int pageSize
-    ) {
-        Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);
-        return ApiResponseDto.onSuccess(getAllKnowledgeByPaginationUseCase.execute(pageable));
-    }
-
-    @Operation(summary = "지식 공유 게시판의 인기 게시글 6개를 조회합니다.")
-    @GetMapping("/hot-issue")
-    public ApiResponseDto<List<KnowledgeSummaryResponse>> getHotKnowledge() {
-        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
-        return ApiResponseDto.onSuccess(getHotKnowledgeUseCase.execute(pageable));
-    }
-
-    @Operation(summary = "지식공유 게시글을 검색합니다. 이때 사용되는 항목은 학과 계열과 키워드 리스트입니다" +
-            "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
-    @GetMapping("/search")
-    public ApiResponseDto<KnowledgeListResponse> searchKnowledge(@RequestParam(required = false) String majorType,
-                                                                 @Nullable @RequestParamList(value = "keyword") List<String> keyword,
-                                                                 @RequestParam(defaultValue = "0") int currentPage,
-                                                                 @RequestParam int pageSize) {
-
-        Pageable pageable = PageRequest.of(currentPage, pageSize);
-        return ApiResponseDto.onSuccess(searchKnowledgeUseCase.execute(majorType, keyword, pageable));
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/CreateKnowledgeDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/CreateKnowledgeDummyDataUseCase.java
@@ -2,10 +2,11 @@ package trim.api.domains.knowledge.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import trim.api.domains.freetalk.vo.request.FreeTalkRequest;
 import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.common.annotation.UseCase;
 import trim.domains.board.dao.domain.MajorType;
+import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
 
 import java.util.List;
 
@@ -14,9 +15,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CreateKnowledgeDummyDataUseCase {
 
+    private final MemberAdaptor memberAdaptor;
     private final WriteKnowledgeUseCase writeKnowledgeUseCase;
 
     public Boolean execute(Long memberId, int knowledgeCount) {
+        Member member = memberAdaptor.queryMember(memberId);
         for (int i = 0; i < knowledgeCount; i++) {
             KnowledgeRequest request = KnowledgeRequest.builder()
                     .title("title of Knowledge" + i + "by" + memberId)
@@ -24,7 +27,7 @@ public class CreateKnowledgeDummyDataUseCase {
                     .majorType(MajorType.getRandomMajor().getKey())
                     .tags(List.of("knowledge1", "knowledge2"))
                     .build();
-            writeKnowledgeUseCase.execute(memberId, request);
+            writeKnowledgeUseCase.execute(member, request);
         }
         return true;
     }

--- a/Trim-Api/src/main/java/trim/api/domains/knowledge/service/WriteKnowledgeUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/knowledge/service/WriteKnowledgeUseCase.java
@@ -7,7 +7,6 @@ import trim.api.domains.knowledge.vo.request.KnowledgeRequest;
 import trim.common.annotation.UseCase;
 import trim.domains.board.business.service.KnowledgeDomainService;
 import trim.domains.board.dao.domain.Knowledge;
-import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
 import trim.domains.tag.business.service.TagDomainService;
 
@@ -18,10 +17,8 @@ public class WriteKnowledgeUseCase {
 
     private final KnowledgeDomainService knowledgeDomainService;
     private final TagDomainService tagDomainService;
-    private final MemberAdaptor memberAdaptor;
 
-    public Long execute(Long memberId, KnowledgeRequest knowledgeRequest) {
-        Member member = memberAdaptor.queryMember(memberId);
+    public Long execute(Member member, KnowledgeRequest knowledgeRequest) {
         Knowledge knowledge = knowledgeDomainService
                 .createKnowledge(member, KnowledgeMapper.INSTANCE.toKnowledgeDto(knowledgeRequest));
         tagDomainService.addTagsInBoard(knowledge.getId(), knowledgeRequest.getTags());

--- a/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeAccessApiController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.like.service.GetLikeCountUseCase;
 
-@Tag(name = "[좋아요🔑]")
+@Tag(name = "[좋아요]")
 @RestController
 @RequestMapping("/api/access/likes")
 @RequiredArgsConstructor

--- a/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeAccessApiController.java
@@ -1,0 +1,26 @@
+package trim.api.domains.like.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.domains.like.service.GetLikeCountUseCase;
+
+@Tag(name = "[좋아요🔑]")
+@RestController
+@RequestMapping("/api/access/likes")
+@RequiredArgsConstructor
+public class LikeAccessApiController {
+
+    private final GetLikeCountUseCase getLikeCountUseCase;
+
+    @Operation(summary = "해당 게시글의 좋아요 개수를 조회합니다. 주로 게시글 상세 조회에서 사용될 예정입니다.")
+    @GetMapping("/boards/{boardId}")
+    public ApiResponseDto<Long> getLikeCount(@PathVariable Long boardId) {
+        return ApiResponseDto.onSuccess(getLikeCountUseCase.execute(boardId));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.like.service.ClickLikeAtTheBoardUseCase;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.dao.domain.Member;
 
 @Tag(name = "[좋아요🔑]")
 @RestController
@@ -19,10 +21,11 @@ public class LikeApiController {
     private final ClickLikeAtTheBoardUseCase clickLikeAtTheBoardUseCase;
 
     @Operation(summary = "해당 게시글에 좋아요를 누릅니다.이미 존재하는 좋아요라면 취소합니다.")
-    @PostMapping("/boards/{boardId}/members/{memberId}")
-    public ApiResponseDto<String> clickLikeAtTheBoard(@PathVariable Long boardId,
-                                                       @PathVariable Long memberId) {
-        return ApiResponseDto.onSuccess(clickLikeAtTheBoardUseCase.execute(boardId, memberId));
+    @PostMapping("/boards/{boardId}")
+    public ApiResponseDto<String> clickLikeAtTheBoard(
+            @AuthUser Member member,
+            @PathVariable Long boardId) {
+        return ApiResponseDto.onSuccess(clickLikeAtTheBoardUseCase.execute(boardId, member));
     }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/controller/LikeApiController.java
@@ -3,31 +3,26 @@ package trim.api.domains.like.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import trim.api.common.dto.ApiResponseDto;
 import trim.api.domains.like.service.ClickLikeAtTheBoardUseCase;
-import trim.api.domains.like.service.GetLikeCountUseCase;
 
-@Tag(name = "[좋아요]")
+@Tag(name = "[좋아요🔑]")
 @RestController
 @RequestMapping("/api/likes")
 @RequiredArgsConstructor
 public class LikeApiController {
 
     private final ClickLikeAtTheBoardUseCase clickLikeAtTheBoardUseCase;
-    private final GetLikeCountUseCase getLikeCountUseCase;
 
     @Operation(summary = "해당 게시글에 좋아요를 누릅니다.이미 존재하는 좋아요라면 취소합니다.")
     @PostMapping("/boards/{boardId}/members/{memberId}")
     public ApiResponseDto<String> clickLikeAtTheBoard(@PathVariable Long boardId,
                                                        @PathVariable Long memberId) {
         return ApiResponseDto.onSuccess(clickLikeAtTheBoardUseCase.execute(boardId, memberId));
-    }
-
-    @Operation(summary = "해당 게시글의 좋아요 개수를 조회합니다. 주로 게시글 상세 조회에서 사용될 예정입니다.")
-    @GetMapping("/boards/{boardId}")
-    public ApiResponseDto<Long> getLikeCount(@PathVariable Long boardId) {
-        return ApiResponseDto.onSuccess(getLikeCountUseCase.execute(boardId));
     }
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/like/service/ClickLikeAtTheBoardUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/like/service/ClickLikeAtTheBoardUseCase.java
@@ -3,10 +3,9 @@ package trim.api.domains.like.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import trim.common.annotation.UseCase;
-import trim.common.util.StaticValues;
-import trim.domains.like.business.adaptor.LikeAdaptor;
 import trim.domains.like.business.service.LikeDomainService;
 import trim.domains.like.business.validator.LikeValidator;
+import trim.domains.member.dao.domain.Member;
 
 import static trim.common.util.StaticValues.*;
 
@@ -18,12 +17,12 @@ public class ClickLikeAtTheBoardUseCase {
     private final LikeDomainService likeDomainService;
     private final LikeValidator likeValidator;
 
-    public String execute(Long boardId, Long memberId) {
-        if (likeValidator.isExist(boardId, memberId)) {
-            likeDomainService.removeLikeByBoardAndMember(boardId, memberId);
+    public String execute(Long boardId, Member member) {
+        if (likeValidator.isExist(boardId, member.getId())) {
+            likeDomainService.removeLikeByBoardAndMember(boardId, member.getId());
             return LIKE_REMOVE_STATUS;
         }
-        likeDomainService.createLike(boardId, memberId);
+        likeDomainService.createLike(boardId, member.getId());
         return LIKE_CREATE_STATUS;
     }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/member/service/CreateQuestionDummyDataUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/service/CreateQuestionDummyDataUseCase.java
@@ -5,6 +5,8 @@ import trim.api.domains.question.service.WriteQuestionUseCase;
 import trim.api.domains.question.vo.request.QuestionRequest;
 import trim.common.annotation.UseCase;
 import trim.domains.board.dao.domain.MajorType;
+import trim.domains.member.business.adaptor.MemberAdaptor;
+import trim.domains.member.dao.domain.Member;
 
 import java.util.List;
 
@@ -12,9 +14,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CreateQuestionDummyDataUseCase {
 
+    private final MemberAdaptor memberAdaptor;
     private final WriteQuestionUseCase writeQuestionUseCase;
 
     public Boolean execute(Long memberId, int questionCount) {
+        Member member = memberAdaptor.queryMember(memberId);
         for (int i = 0; i < questionCount; i++) {
             QuestionRequest request = QuestionRequest.builder()
                     .content("content Question" + i +"by" + memberId)
@@ -22,7 +26,7 @@ public class CreateQuestionDummyDataUseCase {
                     .title("title Question" + i +"by" + memberId)
                     .tags(List.of("dummy1", "dummy2", "dummy3"))
                     .build();
-            writeQuestionUseCase.execute(memberId, request);
+            writeQuestionUseCase.execute(member, request);
         }
         return true;
     }

--- a/Trim-Api/src/main/java/trim/api/domains/member/service/LoginForTestUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/member/service/LoginForTestUseCase.java
@@ -13,7 +13,6 @@ public class LoginForTestUseCase {
 
     private final TokenService tokenService;
 
-
     public JwtToken execute(String username) {
         return tokenService.login(username);
     }

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionAccessApiController.java
@@ -1,0 +1,75 @@
+package trim.api.domains.question.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import trim.api.common.dto.ApiResponseDto;
+import trim.api.common.util.PageUtil;
+import trim.api.domains.question.service.*;
+import trim.api.domains.question.vo.response.QuestionDetailResponse;
+import trim.api.domains.question.vo.response.QuestionListResponse;
+import trim.api.domains.question.vo.response.QuestionSummaryResponse;
+import trim.common.annotation.RequestParamList;
+
+import java.util.List;
+
+import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
+
+@Slf4j
+@Tag(name = "[질문 게시판🔑]")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/access/questions")
+public class QuestionAccessApiController {
+
+    private final GetSpecificQuestionUseCase getSpecificQuestionUseCase;
+    private final GetAllQuestionUseCase getAllQuestionUseCase;
+    private final GetAllQuestionByPaginationUseCase getAllQuestionByPaginationUseCase;
+    private final GetHotQuestionsUseCase getHotQuestionsUseCase;
+    private final SearchQuestionsUseCase searchQuestionsUseCase;
+
+    @Operation(summary = "질문 게시판 조회 메서드입니다. 질문 게시판의 pk를 통해 조회합니다.")
+    @GetMapping("/{questionId}")
+    public ApiResponseDto<QuestionDetailResponse> getSpecificQuestion(@PathVariable Long questionId) {
+        return ApiResponseDto.onSuccess(getSpecificQuestionUseCase.execute(questionId));
+    }
+
+    @Operation(summary = "질문 게시판 리스트 조회 메서드입니다.")
+    @GetMapping
+    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestions() {
+        return ApiResponseDto.onSuccess(getAllQuestionUseCase.execute());
+    }
+
+    @Operation(summary = "질문 게시판을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
+    @GetMapping("/page")
+    public ApiResponseDto<QuestionListResponse> getAllQuestionByPagination(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam int pageSize
+    ) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);
+        return ApiResponseDto.onSuccess(getAllQuestionByPaginationUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "질문 게시판의 인기 게시글 6개를 조회합니다.")
+    @GetMapping("/hot-issue")
+    public ApiResponseDto<List<QuestionSummaryResponse>> getHotQuestions() {
+        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
+        return ApiResponseDto.onSuccess(getHotQuestionsUseCase.execute(pageable));
+    }
+
+    @Operation(summary = "질문 게시글을 검색합니다. 이때 사용되는 항목은 학과 계열과 키워드 리스트입니다" +
+            "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
+    @GetMapping("/search")
+    public ApiResponseDto<QuestionListResponse> searchQuestions(@RequestParam(required = false) String majorType,
+                                                                @Nullable @RequestParamList(value = "keyword") List<String> keyword,
+                                                                @RequestParam(defaultValue = "0") int currentPage,
+                                                                @RequestParam int pageSize) {
+        Pageable pageable = PageRequest.of(currentPage, pageSize);
+        return ApiResponseDto.onSuccess(searchQuestionsUseCase.execute(majorType, keyword, pageable));
+    }
+}

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionAccessApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionAccessApiController.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
 
 @Slf4j
-@Tag(name = "[질문 게시판🔑]")
+@Tag(name = "[질문 게시판]")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/access/questions")

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -6,8 +6,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.domains.question.service.*;
+import trim.api.domains.question.service.EditQuestionUseCase;
+import trim.api.domains.question.service.WriteQuestionUseCase;
 import trim.api.domains.question.vo.request.QuestionRequest;
+import trim.common.annotation.AuthUser;
+import trim.domains.member.dao.domain.Member;
 
 @Slf4j
 @Tag(name = "[질문 게시판🔑]")
@@ -21,21 +24,21 @@ public class QuestionApiController {
 
 
     @Operation(summary = "질문 게시판 작성 메서드입니다.")
-    @PostMapping("/members/{memberId}")
-    public ApiResponseDto<Long> createQuestion(@PathVariable Long memberId, @RequestBody QuestionRequest request) {
-        return ApiResponseDto.onSuccess(writeQuestionUseCase.execute(memberId, request));
+    @PostMapping
+    public ApiResponseDto<Long> createQuestion(@AuthUser Member member,
+                                               @RequestBody QuestionRequest request) {
+        return ApiResponseDto.onSuccess(writeQuestionUseCase.execute(member, request));
 
     }
 
 
     @Operation(summary = "질문 게시판 수정 메서드입니다. 작성자가 질문 게시판 pk를 통해 수정을 할 수 있습니다.")
-    @PatchMapping("/{questionId}/members/{memberId}")
-    public ApiResponseDto<Boolean> updateQuestion(@PathVariable Long memberId,
+    @PatchMapping("/{questionId}")
+    public ApiResponseDto<Boolean> updateQuestion(@AuthUser Member member,
                                                   @PathVariable Long questionId,
                                                   @RequestBody QuestionRequest request) {
-        editQuestionUseCase.execute(memberId, questionId, request);
+        editQuestionUseCase.execute(member, questionId, request);
         return ApiResponseDto.onSuccess(true);
     }
-
 
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/controller/QuestionApiController.java
@@ -2,27 +2,15 @@ package trim.api.domains.question.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import trim.api.common.dto.ApiResponseDto;
-import trim.api.common.util.PageUtil;
 import trim.api.domains.question.service.*;
 import trim.api.domains.question.vo.request.QuestionRequest;
-import trim.api.domains.question.vo.response.QuestionDetailResponse;
-import trim.api.domains.question.vo.response.QuestionListResponse;
-import trim.api.domains.question.vo.response.QuestionSummaryResponse;
-import trim.common.annotation.RequestParamList;
-
-import java.util.List;
-
-import static trim.common.util.StaticValues.HOT_ISSUE_COUNT;
 
 @Slf4j
-@Tag(name = "[질문 게시판]")
+@Tag(name = "[질문 게시판🔑]")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/questions")
@@ -30,11 +18,7 @@ public class QuestionApiController {
 
     private final WriteQuestionUseCase writeQuestionUseCase;
     private final EditQuestionUseCase editQuestionUseCase;
-    private final GetSpecificQuestionUseCase getSpecificQuestionUseCase;
-    private final GetAllQuestionUseCase getAllQuestionUseCase;
-    private final GetAllQuestionByPaginationUseCase getAllQuestionByPaginationUseCase;
-    private final GetHotQuestionsUseCase getHotQuestionsUseCase;
-    private final SearchQuestionsUseCase searchQuestionsUseCase;
+
 
     @Operation(summary = "질문 게시판 작성 메서드입니다.")
     @PostMapping("/members/{memberId}")
@@ -43,20 +27,9 @@ public class QuestionApiController {
 
     }
 
-    @Operation(summary = "질문 게시판 조회 메서드입니다. 질문 게시판의 pk를 통해 조회합니다.")
-    @GetMapping("/{questionId}")
-    public ApiResponseDto<QuestionDetailResponse> getSpecificQuestion(@PathVariable Long questionId) {
-        return ApiResponseDto.onSuccess(getSpecificQuestionUseCase.execute(questionId));
-    }
-
-    @Operation(summary = "질문 게시판 리스트 조회 메서드입니다.")
-    @GetMapping
-    public ApiResponseDto<List<QuestionSummaryResponse>> getAllQuestions() {
-        return ApiResponseDto.onSuccess(getAllQuestionUseCase.execute());
-    }
 
     @Operation(summary = "질문 게시판 수정 메서드입니다. 작성자가 질문 게시판 pk를 통해 수정을 할 수 있습니다.")
-    @PostMapping("/{questionId}/members/{memberId}")
+    @PatchMapping("/{questionId}/members/{memberId}")
     public ApiResponseDto<Boolean> updateQuestion(@PathVariable Long memberId,
                                                   @PathVariable Long questionId,
                                                   @RequestBody QuestionRequest request) {
@@ -64,31 +37,5 @@ public class QuestionApiController {
         return ApiResponseDto.onSuccess(true);
     }
 
-    @Operation(summary = "질문 게시판을 모두 조회합니다. 이때 페이지네이션을 통해 n만큼의 개수만을 불러올 수 있습니다.")
-    @GetMapping("/page")
-    public ApiResponseDto<QuestionListResponse> getAllQuestionByPagination(
-            @RequestParam(defaultValue = "0") int currentPage,
-            @RequestParam int pageSize
-    ) {
-        Pageable pageable = PageRequest.of(currentPage, pageSize, PageUtil.LATEST_SORTING);
-        return ApiResponseDto.onSuccess(getAllQuestionByPaginationUseCase.execute(pageable));
-    }
 
-    @Operation(summary = "질문 게시판의 인기 게시글 6개를 조회합니다.")
-    @GetMapping("/hot-issue")
-    public ApiResponseDto<List<QuestionSummaryResponse>> getHotQuestions() {
-        Pageable pageable = PageRequest.of(0, HOT_ISSUE_COUNT);
-        return ApiResponseDto.onSuccess(getHotQuestionsUseCase.execute(pageable));
-    }
-
-    @Operation(summary = "질문 게시글을 검색합니다. 이때 사용되는 항목은 학과 계열과 키워드 리스트입니다" +
-            "키워드 리스트는 태그, 제목, 컨텐츠의 내용을 확인합니다.")
-    @GetMapping("/search")
-    public ApiResponseDto<QuestionListResponse> searchQuestions(@RequestParam(required = false) String majorType,
-                                                                @Nullable @RequestParamList(value = "keyword") List<String> keyword,
-                                                                @RequestParam(defaultValue = "0") int currentPage,
-                                                                @RequestParam int pageSize) {
-        Pageable pageable = PageRequest.of(currentPage, pageSize);
-        return ApiResponseDto.onSuccess(searchQuestionsUseCase.execute(majorType, keyword, pageable));
-    }
 }

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/EditQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/EditQuestionUseCase.java
@@ -7,7 +7,6 @@ import trim.domains.board.business.adaptor.QuestionAdaptor;
 import trim.domains.board.business.service.QuestionDomainService;
 import trim.domains.board.business.validate.BoardValidate;
 import trim.domains.board.dao.domain.Question;
-import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
 
 @UseCase
@@ -17,11 +16,10 @@ public class EditQuestionUseCase {
     private final QuestionDomainService questionDomainService;
     private final QuestionAdaptor questionAdaptor;
     private final BoardValidate boardValidate;
-    private final MemberAdaptor memberAdaptor;
 
-    public void execute(Long memberId, Long questionId, QuestionRequest request){
+    public void execute(Member member, Long questionId, QuestionRequest request){
         Question question = questionAdaptor.queryById(questionId);
-        boardValidate.checkIsWriter(memberAdaptor.queryMember(memberId), question);
+        boardValidate.checkIsWriter(member, question);
         questionDomainService.editQuestion(question, request.from());
     }
 

--- a/Trim-Api/src/main/java/trim/api/domains/question/service/WriteQuestionUseCase.java
+++ b/Trim-Api/src/main/java/trim/api/domains/question/service/WriteQuestionUseCase.java
@@ -10,8 +10,6 @@ import trim.domains.board.business.service.QuestionDomainService;
 import trim.domains.board.dao.domain.Question;
 import trim.domains.member.business.adaptor.MemberAdaptor;
 import trim.domains.member.dao.domain.Member;
-import trim.domains.mission.business.adaptor.MissionAdaptor;
-import trim.domains.mission.business.service.MissionDomainService;
 import trim.domains.tag.business.service.TagDomainService;
 
 
@@ -25,10 +23,9 @@ public class WriteQuestionUseCase {
     private final QuestionDomainService questionDomainService;
     private final TagDomainService tagDomainService;
 
-    public Long execute(Long memberId, QuestionRequest questionRequest) {
-        Member writer = memberAdaptor.queryMember(memberId);
+    public Long execute(Member member, QuestionRequest questionRequest) {
         Question question = questionDomainService.writeQuestion(
-                writer,
+                member,
                 QuestionMapper.INSTANCE.toQuestionDto(questionRequest)
         );
         tagDomainService.addTagsInBoard(question.getId(), questionRequest.getTags());

--- a/Trim-Common/src/main/java/trim/common/annotation/AuthUser.java
+++ b/Trim-Common/src/main/java/trim/common/annotation/AuthUser.java
@@ -1,0 +1,10 @@
+package trim.common.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthUser {
+    boolean errorOnInvalidType() default true;
+}

--- a/Trim-Common/src/main/java/trim/common/util/AnnotationUtil.java
+++ b/Trim-Common/src/main/java/trim/common/util/AnnotationUtil.java
@@ -1,0 +1,24 @@
+package trim.common.util;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.annotation.Annotation;
+
+public class AnnotationUtil {
+
+    public static <T extends Annotation> T findMethodAnnotation(Class<T> annotationClass, MethodParameter parameter) {
+        T annotation = parameter.getParameterAnnotation(annotationClass);
+        if (annotation != null) {
+            return annotation;
+        }
+        Annotation[] annotationsToSearch = parameter.getParameterAnnotations();
+        for (Annotation toSearch : annotationsToSearch) {
+            annotation = AnnotationUtils.findAnnotation(toSearch.annotationType(), annotationClass);
+            if (annotation != null) {
+                return annotation;
+            }
+        }
+        return null;
+    }
+}

--- a/Trim-Common/src/main/java/trim/common/util/StaticValues.java
+++ b/Trim-Common/src/main/java/trim/common/util/StaticValues.java
@@ -22,4 +22,7 @@ public class StaticValues {
             List.of(
                     "/", "/.well-known/**", "/css/**", "/*.ico", "/error", "/images/**"
             );
+    public static final String JWT = "JWT";
+    public static final String BEARER = "Bearer";
+    public static final String AUTHORIZATION = "Authorization";
 }

--- a/Trim-Domain/src/main/java/trim/domains/member/business/adaptor/MemberAdaptorImpl.java
+++ b/Trim-Domain/src/main/java/trim/domains/member/business/adaptor/MemberAdaptorImpl.java
@@ -1,6 +1,7 @@
 package trim.domains.member.business.adaptor;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import trim.common.annotation.Adaptor;
 import trim.domains.member.dao.domain.Member;
@@ -9,6 +10,7 @@ import trim.domains.member.dao.repository.MemberRepository;
 
 import java.util.List;
 
+@Slf4j
 @Adaptor
 @Transactional(readOnly = true)
 @RequiredArgsConstructor


### PR DESCRIPTION
## #️⃣ 요약 설명
>모든 api를 인증/비인증 으로 분류한다. 이때 구별은 api path를 통해 알 수 있도록 통일한다.
## 📝 작업 내용
- https://github.com/trim-project/trim-back-mm/issues/48
```java
@Tag(name = "[뱃지]")
@RestController
@RequiredArgsConstructor
@RequestMapping("/api/access/badges")
public class BadgeAccessApiController {

    private final GetAllBadgesUseCase getAllBadgesUseCase;

    @Operation(summary = "모든 뱃지를 조회합니다.")
    @GetMapping
    public ApiResponseDto<List<BadgeResponse>> getAllBadges() {
        return ApiResponseDto.onSuccess(getAllBadgesUseCase.execute());
    }
}
```

```java
@Tag(name = "[뱃지🔑]")
@RestController
@RequiredArgsConstructor
@RequestMapping("/api/badges")
public class BadgeApiController {

    private final UpgradeBadgeLevelUseCase upgradeBadgeLevelUseCase;
    private final CountUpBadgeOfWritingBoardUseCase countUpBadgeOfWritingBoardUseCase;
    private final GetAllBadgesByMemberUseCase getAllBadgesByMemberUseCase;


    @Operation(summary = "모든 뱃지를 조회합니다. 이때 사용자의 미션 상태를 반영하여 값을 가져옵니다.")
    @GetMapping("/members/{memberId}")
    public ApiResponseDto<List<BadgeDetailResponse>> getAllBadgesByMember(@PathVariable Long memberId) {
        return ApiResponseDto.onSuccess(getAllBadgesByMemberUseCase.execute(memberId));
    }

    @Operation(summary = "미션의 단계를 업그레이드 합니다. 현재 완성한 배지를 획득합니다.")
    @PostMapping("/{badgeId}/members/{memberId}")
    public ApiResponseDto<Integer> upgradeBadgeLevel(@PathVariable Long badgeId,
                                                     @PathVariable Long memberId) {
        return ApiResponseDto.onSuccess(upgradeBadgeLevelUseCase.execute(badgeId, memberId));
    }

    @Operation(summary = "게시글 작성을 함으로써 미션의 카운트를 하나 올려줍니다.")
    @PutMapping("/boards/members/{memberId}")
    public ApiResponseDto<Long> countUpBadgeOfWritingBoard(@PathVariable Long memberId,
                                                           @RequestParam String badgeContentKey) {
        BadgeContent badgeContent = EnumConvertUtil.convert(BadgeContent.class, badgeContentKey);
        return ApiResponseDto.onSuccess(countUpBadgeOfWritingBoardUseCase
                .execute(badgeContent, memberId));
    }

}

```

위 두 코드를 보면 알 수 있듯이 스웨거의 제목에는 키 이모티콘을 통해, api 주소에는 access의 유무에 따라 인증/비인증을 나누었다.
